### PR TITLE
Fix architecture detection for VC 2005 2008 2010.

### DIFF
--- a/cmake/modules/hunter_setup_msvc_arch.cmake
+++ b/cmake/modules/hunter_setup_msvc_arch.cmake
@@ -61,7 +61,7 @@ macro(hunter_setup_msvc_arch)
     string(
         REGEX
         REPLACE
-        "^ 20[1-9][1-9]"
+        "^ 20[0-9][0-9]"
         ""
         HUNTER_MSVC_ARCH
         "${HUNTER_MSVC_ARCH}"


### PR DESCRIPTION
The regex didn't allow a 0 in either of the final two positions, so would fail to detect the architecture for MSVC 2005, 2008 or 2010.
