### PR TITLE
Added libpng.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,14 @@ env:
     - PROJECT_DIR=examples/OpenSSL TOOLCHAIN=ios-nocodesign
     - PROJECT_DIR=examples/OpenSSL TOOLCHAIN=analyze
     #
+    - PROJECT_DIR=examples/PNG TOOLCHAIN=default
+    - PROJECT_DIR=examples/PNG TOOLCHAIN=libcxx
+    - PROJECT_DIR=examples/PNG TOOLCHAIN=clang-libstdcxx
+    - PROJECT_DIR=examples/PNG TOOLCHAIN=xcode
+    - PROJECT_DIR=examples/PNG TOOLCHAIN=gcc
+    - PROJECT_DIR=examples/PNG TOOLCHAIN=ios-nocodesign
+    - PROJECT_DIR=examples/PNG TOOLCHAIN=analyze
+    #
     - PROJECT_DIR=examples/Sugar TOOLCHAIN=default
     - PROJECT_DIR=examples/Sugar TOOLCHAIN=libcxx
     - PROJECT_DIR=examples/Sugar TOOLCHAIN=clang-libstdcxx

--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -29,6 +29,7 @@ hunter_config(Libcxx VERSION 3.5.0)
 hunter_config(Libcxxabi VERSION 3.5.0)
 hunter_config(Libssh2 VERSION 1.4.4_DEV-cmake)
 hunter_config(OpenSSL VERSION 1.0.2a)
+hunter_config(PNG VERSION 1.6.16)
 hunter_config(RapidJSON VERSION 0.11-hunter)
 hunter_config(Sober VERSION 0.1.0) # Relax warnings
 hunter_config(Sugar VERSION 1.2.2)

--- a/cmake/find/FindPNG.cmake
+++ b/cmake/find/FindPNG.cmake
@@ -1,0 +1,125 @@
+#.rst:
+# FindPNG
+# -------
+#
+# Find the native PNG includes and library
+#
+#
+#
+# This module searches libpng, the library for working with PNG images.
+#
+# It defines the following variables
+#
+# ``PNG_INCLUDE_DIRS``
+#   where to find png.h, etc.
+# ``PNG_LIBRARIES``
+#   the libraries to link against to use PNG.
+# ``PNG_DEFINITIONS``
+#   You should add_definitons(${PNG_DEFINITIONS}) before compiling code
+#   that includes png library files.
+# ``PNG_FOUND``
+#   If false, do not try to use PNG.
+# ``PNG_VERSION_STRING``
+#   the version of the PNG library found (since CMake 2.8.8)
+#
+# Also defined, but not for general use are
+#
+# ``PNG_LIBRARY``
+#   where to find the PNG library.
+#
+# For backward compatiblity the variable PNG_INCLUDE_DIR is also set.
+# It has the same value as PNG_INCLUDE_DIRS.
+#
+# Since PNG depends on the ZLib compression library, none of the above
+# will be defined unless ZLib can be found.
+
+#=============================================================================
+# Copyright 2002-2009 Kitware, Inc.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+if(PNG_FIND_QUIETLY)
+  set(_FIND_ZLIB_ARG QUIET)
+endif()
+find_package(ZLIB ${_FIND_ZLIB_ARG})
+
+if(ZLIB_FOUND)
+  find_path(PNG_PNG_INCLUDE_DIR png.h
+  /usr/local/include/libpng             # OpenBSD
+  )
+
+  list(APPEND PNG_NAMES png libpng)
+  unset(PNG_NAMES_DEBUG)
+  set(_PNG_VERSION_SUFFIXES 17 16 15 14 12)
+  if (PNG_FIND_VERSION MATCHES "^([0-9]+)\\.([0-9]+)(\\..*)?$")
+    set(_PNG_VERSION_SUFFIX_MIN "${CMAKE_MATCH_1}${CMAKE_MATCH_2}")
+    if (PNG_FIND_VERSION_EXACT)
+      set(_PNG_VERSION_SUFFIXES ${_PNG_VERSION_SUFFIX_MIN})
+    else ()
+      string(REGEX REPLACE
+          "${_PNG_VERSION_SUFFIX_MIN}.*" "${_PNG_VERSION_SUFFIX_MIN}"
+          _PNG_VERSION_SUFFIXES "${_PNG_VERSION_SUFFIXES}")
+    endif ()
+    unset(_PNG_VERSION_SUFFIX_MIN)
+  endif ()
+  foreach(v IN LISTS _PNG_VERSION_SUFFIXES)
+    list(APPEND PNG_NAMES png${v} libpng${v} png${v}_static libpng${v}_static)
+    list(APPEND PNG_NAMES_DEBUG png${v}_staticd libpng${v}_staticd)
+  endforeach()
+  unset(_PNG_VERSION_SUFFIXES)
+  # For compatiblity with versions prior to this multi-config search, honor
+  # any PNG_LIBRARY that is already specified and skip the search.
+  if(NOT PNG_LIBRARY)
+    find_library(PNG_LIBRARY_RELEASE NAMES ${PNG_NAMES})
+    find_library(PNG_LIBRARY_DEBUG NAMES ${PNG_NAMES_DEBUG})
+    include(SelectLibraryConfigurations)
+    select_library_configurations(PNG)
+    mark_as_advanced(PNG_LIBRARY_RELEASE PNG_LIBRARY_DEBUG)
+  endif()
+  unset(PNG_NAMES)
+  unset(PNG_NAMES_DEBUG)
+
+  # Set by select_library_configurations(), but we want the one from
+  # find_package_handle_standard_args() below.
+  unset(PNG_FOUND)
+
+  if (PNG_LIBRARY AND PNG_PNG_INCLUDE_DIR)
+      # png.h includes zlib.h. Sigh.
+      set(PNG_INCLUDE_DIRS ${PNG_PNG_INCLUDE_DIR} ${ZLIB_INCLUDE_DIR} )
+      set(PNG_INCLUDE_DIR ${PNG_INCLUDE_DIRS} ) # for backward compatiblity
+      set(PNG_LIBRARIES ${PNG_LIBRARY} ${ZLIB_LIBRARY})
+
+      if (CYGWIN)
+        if(BUILD_SHARED_LIBS)
+           # No need to define PNG_USE_DLL here, because it's default for Cygwin.
+        else()
+          set (PNG_DEFINITIONS -DPNG_STATIC)
+        endif()
+      endif ()
+
+  endif ()
+
+  if (PNG_PNG_INCLUDE_DIR AND EXISTS "${PNG_PNG_INCLUDE_DIR}/png.h")
+      file(STRINGS "${PNG_PNG_INCLUDE_DIR}/png.h" png_version_str REGEX "^#define[ \t]+PNG_LIBPNG_VER_STRING[ \t]+\".+\"")
+
+      string(REGEX REPLACE "^#define[ \t]+PNG_LIBPNG_VER_STRING[ \t]+\"([^\"]+)\".*" "\\1" PNG_VERSION_STRING "${png_version_str}")
+      unset(png_version_str)
+  endif ()
+endif()
+
+# handle the QUIETLY and REQUIRED arguments and set PNG_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PNG
+                                  REQUIRED_VARS PNG_LIBRARY PNG_PNG_INCLUDE_DIR
+                                  VERSION_VAR PNG_VERSION_STRING)
+
+mark_as_advanced(PNG_PNG_INCLUDE_DIR PNG_LIBRARY )

--- a/cmake/projects/PNG/hunter.cmake
+++ b/cmake/projects/PNG/hunter.cmake
@@ -1,0 +1,42 @@
+ # Copyright (c) 2014, Ruslan Baratov
+# Copyright (c) 2015, Alexander Lamaison
+# All rights reserved.
+
+if(DEFINED HUNTER_CMAKE_PROJECTS_PNG_HUNTER_CMAKE_)
+  return()
+else()
+  set(HUNTER_CMAKE_PROJECTS_PNG_HUNTER_CMAKE_ 1)
+endif()
+
+include(hunter_add_version)
+include(hunter_add_version_start)
+include(hunter_cmake_args)
+include(hunter_download)
+include(hunter_pick_scheme)
+
+hunter_add_version_start(PNG)
+
+hunter_add_version(
+    PACKAGE_NAME
+    PNG
+    VERSION
+    "1.6.16"
+    URL
+    "https://github.com/alamaison/libpng/archive/v1.6.16-hunter-3.tar.gz"
+    SHA1
+    903f19355c16221f8c8fa9253bda85c7d74ece3a
+)
+
+hunter_cmake_args(
+    PNG
+    CMAKE_ARGS
+      PNG_SHARED=OFF
+      PNG_TESTS=OFF
+)
+
+hunter_pick_scheme(
+    DEFAULT url_sha1_release_debug
+    COMBINED url_sha1_combined_release_debug
+)
+
+hunter_download(PACKAGE_NAME PNG)

--- a/examples/PNG/CMakeLists.txt
+++ b/examples/PNG/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (c) 2014, Ruslan Baratov
+# Copyright (c) 2015, Alexander Lamaison
+# All rights reserved.
+
+cmake_minimum_required(VERSION 3.0)
+project(example-hunter-png)
+
+# See https://github.com/ruslo/hunter/issues/50
+set(HUNTER_SKIP_TOOLCHAIN_VERIFICATION YES)
+
+# Emulate HunterGate:
+# * https://github.com/hunter-packages/gate
+include("../common.cmake")
+
+hunter_add_package(PNG)
+
+find_package(PNG REQUIRED)
+
+add_executable(foo main.cpp)
+target_compile_definitions(foo PRIVATE ${PNG_DEFINITIONS})
+target_include_directories(foo PRIVATE ${PNG_INCLUDE_DIRS})
+target_link_libraries(foo PRIVATE ${PNG_LIBRARIES})

--- a/examples/PNG/main.cpp
+++ b/examples/PNG/main.cpp
@@ -1,0 +1,148 @@
+/*
+ * A simple libpng example program
+ * http://zarb.org/~gc/html/libpng.html
+ *
+ * Modified by Yoshimasa Niwa to make it much simpler
+ * and support all defined color_type.
+ *
+ * To build, use the next instruction on OS X.
+ * $ brew install libpng
+ * $ clang -lz -lpng15 libpng_test.c
+ *
+ * Copyright 2002-2010 Guillaume Cottenceau.
+ *
+ * This software may be freely redistributed under the terms
+ * of the X11 license.
+ *
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <png.h>
+
+int width, height;
+png_byte color_type;
+png_byte bit_depth;
+png_bytep *row_pointers;
+
+void read_png_file(char *filename) {
+  FILE *fp = fopen(filename, "rb");
+
+  png_structp png = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+  if(!png) abort();
+
+  png_infop info = png_create_info_struct(png);
+  if(!info) abort();
+
+  if(setjmp(png_jmpbuf(png))) abort();
+
+  png_init_io(png, fp);
+
+  png_read_info(png, info);
+
+  width      = png_get_image_width(png, info);
+  height     = png_get_image_height(png, info);
+  color_type = png_get_color_type(png, info);
+  bit_depth  = png_get_bit_depth(png, info);
+
+  // Read any color_type into 8bit depth, RGBA format.
+  // See http://www.libpng.org/pub/png/libpng-manual.txt
+
+  if(bit_depth == 16)
+    png_set_strip_16(png);
+
+  if(color_type == PNG_COLOR_TYPE_PALETTE)
+    png_set_palette_to_rgb(png);
+
+  // PNG_COLOR_TYPE_GRAY_ALPHA is always 8 or 16bit depth.
+  if(color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8)
+    png_set_expand_gray_1_2_4_to_8(png);
+
+  if(png_get_valid(png, info, PNG_INFO_tRNS))
+    png_set_tRNS_to_alpha(png);
+
+  // These color_type don't have an alpha channel then fill it with 0xff.
+  if(color_type == PNG_COLOR_TYPE_RGB ||
+     color_type == PNG_COLOR_TYPE_GRAY ||
+     color_type == PNG_COLOR_TYPE_PALETTE)
+    png_set_filler(png, 0xFF, PNG_FILLER_AFTER);
+
+  if(color_type == PNG_COLOR_TYPE_GRAY ||
+     color_type == PNG_COLOR_TYPE_GRAY_ALPHA)
+    png_set_gray_to_rgb(png);
+
+  png_read_update_info(png, info);
+
+  row_pointers = (png_bytep*)malloc(sizeof(png_bytep) * height);
+  for(int y = 0; y < height; y++) {
+    row_pointers[y] = (png_byte*)malloc(png_get_rowbytes(png,info));
+  }
+
+  png_read_image(png, row_pointers);
+
+  fclose(fp);
+}
+
+void write_png_file(char *filename) {
+
+  FILE *fp = fopen(filename, "wb");
+  if(!fp) abort();
+
+  png_structp png = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+  if (!png) abort();
+
+  png_infop info = png_create_info_struct(png);
+  if (!info) abort();
+
+  if (setjmp(png_jmpbuf(png))) abort();
+
+  png_init_io(png, fp);
+
+  // Output is 8bit depth, RGBA format.
+  png_set_IHDR(
+    png,
+    info,
+    width, height,
+    8,
+    PNG_COLOR_TYPE_RGBA,
+    PNG_INTERLACE_NONE,
+    PNG_COMPRESSION_TYPE_DEFAULT,
+    PNG_FILTER_TYPE_DEFAULT
+  );
+  png_write_info(png, info);
+
+  // To remove the alpha channel for PNG_COLOR_TYPE_RGB format,
+  // Use png_set_filler().
+  //png_set_filler(png, 0, PNG_FILLER_AFTER);
+
+  png_write_image(png, row_pointers);
+  png_write_end(png, NULL);
+
+  for(int y = 0; y < height; y++) {
+    free(row_pointers[y]);
+  }
+  free(row_pointers);
+
+  fclose(fp);
+}
+
+void process_png_file() {
+  for(int y = 0; y < height; y++) {
+    png_bytep row = row_pointers[y];
+    for(int x = 0; x < width; x++) {
+      png_bytep px = &(row[x * 4]);
+      // Do something awesome for each pixel here...
+      printf("%4d, %4d = RGBA(%3d, %3d, %3d, %3d)\n", x, y, px[0], px[1], px[2], px[3]);
+    }
+  }
+}
+
+int main(int argc, char *argv[]) {
+  if(argc != 3) abort();
+
+  read_png_file(argv[1]);
+  process_png_file();
+  write_png_file(argv[2]);
+
+  return 0;
+}


### PR DESCRIPTION
Usage:
```cmake
  hunter_add_package(PNG)

  find_package(PNG REQUIRED)

  add_executable(foo main.cpp)
  target_compile_definitions(foo PRIVATE ${PNG_DEFINITIONS})
  target_include_directories(foo PRIVATE ${PNG_INCLUDE_DIRS})
  target_link_libraries(foo PRIVATE ${PNG_LIBRARIES})
```

Unfortunately, the FindPNG.cmake shipped with CMake does not include the _static prefix in the name options, so doesn't find the static library.  The version included here makes that simple change.