### PR TITLE
Handle skipping toolchain verification internally

### DIFF
--- a/cmake/projects/Libssh2/hunter.cmake
+++ b/cmake/projects/Libssh2/hunter.cmake
@@ -37,6 +37,8 @@ hunter_cmake_args(
       BUILD_TESTING=OFF
       BUILD_EXAMPLES=OFF
       HUNTER_ENABLED=ON
+      # Remove once https://github.com/ruslo/hunter/issues/50 is fixed
+      HUNTER_SKIP_TOOLCHAIN_VERIFICATION=ON
 )
 
 hunter_download(PACKAGE_NAME Libssh2)

--- a/cmake/projects/PNG/hunter.cmake
+++ b/cmake/projects/PNG/hunter.cmake
@@ -32,6 +32,8 @@ hunter_cmake_args(
     CMAKE_ARGS
       PNG_SHARED=OFF
       PNG_TESTS=OFF
+      # Remove once https://github.com/ruslo/hunter/issues/50 is fixed
+      HUNTER_SKIP_TOOLCHAIN_VERIFICATION=ON
 )
 
 hunter_pick_scheme(

--- a/examples/Libssh2/CMakeLists.txt
+++ b/examples/Libssh2/CMakeLists.txt
@@ -5,9 +5,6 @@
 cmake_minimum_required(VERSION 3.0)
 project(download-libssh2)
 
-# See https://github.com/ruslo/hunter/issues/50
-set(HUNTER_SKIP_TOOLCHAIN_VERIFICATION YES)
-
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate
 include("../common.cmake")

--- a/examples/PNG/CMakeLists.txt
+++ b/examples/PNG/CMakeLists.txt
@@ -5,9 +5,6 @@
 cmake_minimum_required(VERSION 3.0)
 project(example-hunter-png)
 
-# See https://github.com/ruslo/hunter/issues/50
-set(HUNTER_SKIP_TOOLCHAIN_VERIFICATION YES)
-
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate
 include("../common.cmake")


### PR DESCRIPTION
Specifying HUNTER_SKIP_TOOLCHAIN_VERIFICATION should be something Hunter does internally, when necessary.  Client projects shouldn't have to do this themselves.