### PR TITLE
Adding IOSTREAMS_NO_BZIP2 CMAKE_ARG for Boost package

### DIFF
--- a/cmake/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/schemes/url_sha1_boost_library.cmake.in
@@ -201,6 +201,13 @@ set(
     --with-@HUNTER_PACKAGE_COMPONENT@
 )
 
+string(COMPARE EQUAL "@HUNTER_PACKAGE_COMPONENT@" "iostreams" is_iostreams)
+if(is_iostreams)
+if(IOSTREAMS_NO_BZIP2)
+  list(APPEND build_opts -s NO_BZIP2=1)
+endif(IOSTREAMS_NO_BZIP2)
+endif(is_iostreams)
+
 if(CMAKE_CXX_FLAGS)
   list(APPEND build_opts "cxxflags=${CMAKE_CXX_FLAGS}")
 endif()


### PR DESCRIPTION
Adding the NO_BZIP2 flag as requested