### PR TITLE
Pass C/CXX ABI info to subprojects from top-level configuration.

### DIFF
--- a/cmake/modules/hunter_create_cache_file.cmake
+++ b/cmake/modules/hunter_create_cache_file.cmake
@@ -51,6 +51,51 @@ function(hunter_create_cache_file cache_path)
       "set(HUNTER_STATUS_DEBUG \"${HUNTER_STATUS_DEBUG}\" CACHE INTERNAL \"\")\n"
   )
 
+  # Pass compiler ABI info through to avoid recalculating in every project
+  foreach(lang C CXX)
+    if(DEFINED CMAKE_${lang}_SIZEOF_DATA_PTR)
+      file(
+          APPEND
+          "${temp_path}"
+          "set(CMAKE_${lang}_SIZEOF_DATA_PTR \"${CMAKE_${lang}_SIZEOF_DATA_PTR}\" CACHE INTERNAL \"\")\n"
+      )
+    endif()
+    if(DEFINED CMAKE_${lang}_COMPILER_ABI)
+      file(
+          APPEND
+          "${temp_path}"
+          "set(CMAKE_${lang}_COMPILER_ABI \"${CMAKE_${lang}_COMPILER_ABI}\" CACHE INTERNAL \"\")\n"
+      )
+    endif()
+    file(
+        APPEND
+        "${temp_path}"
+        "set(CMAKE_${lang}_IMPLICIT_LINK_LIBRARIES \"${CMAKE_${lang}_IMPLICIT_LINK_LIBRARIES}\" CACHE INTERNAL \"\")\n"
+    )
+    file(
+        APPEND
+        "${temp_path}"
+        "set(CMAKE_${lang}_IMPLICIT_LINK_DIRECTORIES \"${CMAKE_${lang}_IMPLICIT_LINK_DIRECTORIES}\" CACHE INTERNAL \"\")\n"
+    )
+    file(
+        APPEND
+        "${temp_path}"
+        "set(CMAKE_${lang}_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES \"${CMAKE_${lang}_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES}\" CACHE INTERNAL \"\")\n"
+    )
+    if(DEFINED CMAKE_${lang}_LIBRARY_ARCHITECTURE)
+      file(
+          APPEND
+          "${temp_path}"
+          "set(CMAKE_${lang}_LIBRARY_ARCHITECTURE \"${CMAKE_${lang}_LIBRARY_ARCHITECTURE}\" CACHE INTERNAL \"\")\n"
+      )
+    endif()
+    file(
+        APPEND
+        "${temp_path}"
+        "set(CMAKE_${lang}_ABI_COMPILED \"${CMAKE_${lang}_ABI_COMPILED}\" CACHE INTERNAL \"\")\n"
+    )
+  endforeach()
+
   if(HUNTER_STATUS_DEBUG)
     file(
         APPEND

--- a/cmake/modules/hunter_create_cache_file.cmake
+++ b/cmake/modules/hunter_create_cache_file.cmake
@@ -1,6 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
+include(hunter_status_debug)
 include(hunter_test_string_not_empty)
 
 function(hunter_create_cache_file cache_path)
@@ -54,6 +55,7 @@ function(hunter_create_cache_file cache_path)
   # Pass compiler ABI info through to avoid recalculating in every project
   foreach(lang C CXX)
     if(DEFINED CMAKE_${lang}_SIZEOF_DATA_PTR)
+      hunter_status_debug("ABI forwarding: CMAKE_${lang}_SIZEOF_DATA_PTR = ${CMAKE_${lang}_SIZEOF_DATA_PTR}")
       file(
           APPEND
           "${temp_path}"
@@ -61,34 +63,40 @@ function(hunter_create_cache_file cache_path)
       )
     endif()
     if(DEFINED CMAKE_${lang}_COMPILER_ABI)
+      hunter_status_debug("ABI forwarding: CMAKE_${lang}_COMPILER_ABI = ${CMAKE_${lang}_COMPILER_ABI}")
       file(
           APPEND
           "${temp_path}"
           "set(CMAKE_${lang}_COMPILER_ABI \"${CMAKE_${lang}_COMPILER_ABI}\" CACHE INTERNAL \"\")\n"
       )
     endif()
+    hunter_status_debug("ABI forwarding: CMAKE_${lang}_IMPLICIT_LINK_LIBRARIES = ${CMAKE_${lang}_IMPLICIT_LINK_LIBRARIES}")
     file(
         APPEND
         "${temp_path}"
         "set(CMAKE_${lang}_IMPLICIT_LINK_LIBRARIES \"${CMAKE_${lang}_IMPLICIT_LINK_LIBRARIES}\" CACHE INTERNAL \"\")\n"
     )
+    hunter_status_debug("ABI forwarding: CMAKE_${lang}_IMPLICIT_LINK_DIRECTORIES = ${CMAKE_${lang}_IMPLICIT_LINK_DIRECTORIES}")
     file(
         APPEND
         "${temp_path}"
         "set(CMAKE_${lang}_IMPLICIT_LINK_DIRECTORIES \"${CMAKE_${lang}_IMPLICIT_LINK_DIRECTORIES}\" CACHE INTERNAL \"\")\n"
     )
+    hunter_status_debug("ABI forwarding: CMAKE_${lang}_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES = ${CMAKE_${lang}_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES}")
     file(
         APPEND
         "${temp_path}"
         "set(CMAKE_${lang}_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES \"${CMAKE_${lang}_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES}\" CACHE INTERNAL \"\")\n"
     )
     if(DEFINED CMAKE_${lang}_LIBRARY_ARCHITECTURE)
+      hunter_status_debug("ABI forwarding: CMAKE_${lang}_LIBRARY_ARCHITECTURE = ${CMAKE_${lang}_LIBRARY_ARCHITECTURE}")
       file(
           APPEND
           "${temp_path}"
           "set(CMAKE_${lang}_LIBRARY_ARCHITECTURE \"${CMAKE_${lang}_LIBRARY_ARCHITECTURE}\" CACHE INTERNAL \"\")\n"
       )
     endif()
+    hunter_status_debug("ABI forwarding: CMAKE_${lang}_ABI_COMPILED = ${CMAKE_${lang}_ABI_COMPILED}")
     file(
         APPEND
         "${temp_path}"


### PR DESCRIPTION
Speeds up the build slightly, because it doesn't have to be recalculated in every subproject.  Also helps avoid #121 because the top-level project is less likely to run into the long-path problem while compiling the ABI test.

Closes #122.