### PR TITLE
Revert parallel build for MSVC.

### DIFF
--- a/cmake/modules/hunter_jobs_number.cmake
+++ b/cmake/modules/hunter_jobs_number.cmake
@@ -34,14 +34,5 @@ function(hunter_jobs_number jobs_options_varname toolchain_path)
     return()
   endif()
 
-  if(MSVC)
-    file(
-        APPEND
-        "${toolchain_path}"
-        "set(CMAKE_CXX_FLAGS \"\${CMAKE_CXX_FLAGS} /MP\" CACHE STRING \"\" FORCE)\n"
-        "set(CMAKE_C_FLAGS \"\${CMAKE_C_FLAGS} /MP\" CACHE STRING \"\" FORCE)\n"
-    )
-  endif()
-
   set("${jobs_options_varname}" "" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
Target-level parallelism, introduced in v0.8.13 bf2703b5bab618ae709ffc7bed6c16c18e0993ea, breaks C++ compilation in MSVC because it overwrites important flags, including the flag to enable exceptions (#142).

Until a solution is found, this change reverts the offending code so the binaries produced by Hunter are, at least, usable.