### PR TITLE
Fix Boost.Regex build with Visual Studio 2005.

### DIFF
--- a/cmake/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/schemes/url_sha1_boost_library.cmake.in
@@ -284,6 +284,11 @@ ExternalProject_Add(
     ${build_opts}
     stage # install only libraries, headers installed in `url_sha1_boost`
     "--stagedir=@HUNTER_PACKAGE_INSTALL_PREFIX@"
+    # Logging as Workaround for VS_UNICODE_OUTPUT issue:
+    # https://public.kitware.com/Bug/view.php?id=14266
+    LOG_CONFIGURE 1
+    LOG_BUILD 1
+    LOG_INSTALL 1
 )
 
 if(APPLE)


### PR DESCRIPTION
This fixes a problem caused by running bjam (b2) from within a Visual Studio build.  In our case, that happens because bjam is run from CMake ExternalProject, which creates a VisualStudio project to run the commands.

Boost's bjam captures the compiler log so that it can run configure-style tests without them appearing as errors in the log. Visual Studio 2005 (possibly later versions too) sets an environment variable, VS_UNICODE_OUTPUT, that causes cl.exe to output a unicode log to a special pipe.    This causes the configure-stage output to leak into the log that Visual Studio sees, and VS aborts the build thinking there was a failure, even when there wasn't.

According to this bug report https://public.kitware.com/Bug/view.php?id=14266, this has been fixed.  However, the fix must not be working (test CMake 3.1 and 3.2).  The bug report mentions that enabling logging in ExternalProject happens to have the desired effect, because it wraps the bjam command in other script that isolates it from Visual Studio's environment.

This change uses the logging workaround to fix the problem in Hunter.  I'm not sure why I didn't see this in the past.  The ExternalProject command in url_sha1_boost_library.cmake.in has changed a bit, but not in any way that would obviously cause this change.

See more:
http://lists.boost.org/boost-users/2013/04/78414.php
http://blogs.msdn.com/b/freik/archive/2006/04/05/569025.aspx