### PR TITLE
Boost compiles with Android

### DIFF
--- a/cmake/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/schemes/url_sha1_boost_library.cmake.in
@@ -145,33 +145,33 @@ if(is_mpi)
     if(NOT MPI_CXX_FOUND)
       # Fix concurrent output to console
       execute_process(
-        COMMAND
-        "@CMAKE_COMMAND@"
-        -E
-        echo
-        "MPI is required. Please install it. For example MS-MPI: "
-        "http://msdn.microsoft.com/en-us/library/bb524831%28v=vs.85%29.aspx"
+          COMMAND
+          "@CMAKE_COMMAND@"
+          -E
+          echo
+          "MPI is required. Please install it. For example MS-MPI: "
+          "http://msdn.microsoft.com/en-us/library/bb524831%28v=vs.85%29.aspx"
       )
       hunter_fatal_error("MPI is required" WIKI "error.boost.mpi.on.windows")
     endif()
     get_filename_component(MPI_DIR "${MPI_CXX_INCLUDE_PATH}/.." ABSOLUTE)
     string(REPLACE "/" "\\\\" MPI_DIR "${MPI_DIR}")
     configure_file(
-      "@HUNTER_SELF@/scripts/mpi.jam"
-      "@HUNTER_PACKAGE_BUILD_DIR@/tools/build/v2/tools/mpi.jam"
+        "@HUNTER_SELF@/scripts/mpi.jam"
+        "@HUNTER_PACKAGE_BUILD_DIR@/tools/build/v2/tools/mpi.jam"
     )
 
     # HUNTER_PACKAGE_SOURCE_DIR will be removed while unpacking. Save mpi.jam
     # in HUNTER_PACKAGE_BUILD_DIR first and move it to HUNTER_PACKAGE_SOURCE_DIR
     # on configure step
     set(
-      copy_mpi_command
-      COMMAND
-      "@CMAKE_COMMAND@"
-      -E
-      copy
-      "@HUNTER_PACKAGE_BUILD_DIR@/tools/build/v2/tools/mpi.jam"
-      "@HUNTER_PACKAGE_SOURCE_DIR@/tools/build/v2/tools/mpi.jam"
+        copy_mpi_command
+        COMMAND
+        "@CMAKE_COMMAND@"
+        -E
+        copy
+        "@HUNTER_PACKAGE_BUILD_DIR@/tools/build/v2/tools/mpi.jam"
+        "@HUNTER_PACKAGE_SOURCE_DIR@/tools/build/v2/tools/mpi.jam"
     )
   endif()
   set(variants variant=release) # build bug
@@ -183,14 +183,14 @@ endif()
 
 set(boost_user_jam "@HUNTER_PACKAGE_BUILD_DIR@/boost.user.jam")
 file(
-  WRITE
-  ${boost_user_jam}
-  "using ${toolset_name}\n"
-  "  : ${toolset_version}\n"
-  "  : \"${boost_compiler}\"\n"
-  "  : <archiver> \"${CMAKE_AR}\"\n"
-  ";\n"
-  "${using_mpi}\n"
+    WRITE
+    ${boost_user_jam}
+    "using ${toolset_name}\n"
+    "  : ${toolset_version}\n"
+    "  : \"${boost_compiler}\"\n"
+    "  : <archiver> \"${CMAKE_AR}\"\n"
+    ";\n"
+    "${using_mpi}\n"
 )
 
 if("@MSVC@")
@@ -221,21 +221,21 @@ if (toolset_version)
   set(toolset_full_name ${toolset_full_name}-${toolset_version})
 endif()
 set(
-  build_opts
-  -a
-  ${link_opts}
-  threading=multi
-  ${variants}
-  --layout=tagged
-  toolset=${toolset_full_name}
-  "--user-config=${boost_user_jam}"
-  --with-@HUNTER_PACKAGE_COMPONENT@
+    build_opts
+    -a
+    ${link_opts}
+    threading=multi
+    ${variants}
+    --layout=tagged
+    toolset=${toolset_full_name}
+    "--user-config=${boost_user_jam}"
+    --with-@HUNTER_PACKAGE_COMPONENT@
 )
 
 hunter_boost_component_b2_args(
-  "@HUNTER_PACKAGE_COMPONENT@"
-  "@HUNTER_Boost_CMAKE_ARGS@"
-  b2_component_opts
+    "@HUNTER_PACKAGE_COMPONENT@"
+    "@HUNTER_Boost_CMAKE_ARGS@"
+    b2_component_opts
 )
 
 list(APPEND build_opts ${b2_component_opts})
@@ -285,40 +285,40 @@ if(HUNTER_STATUS_DEBUG)
 endif()
 
 ExternalProject_Add(
-  "@HUNTER_EP_NAME@"
-  URL
-  @HUNTER_PACKAGE_URL@
-  URL_HASH
-  SHA1=@HUNTER_PACKAGE_SHA1@
-  DOWNLOAD_DIR
-  "@HUNTER_PACKAGE_DOWNLOAD_DIR@"
-  SOURCE_DIR
-  "@HUNTER_PACKAGE_SOURCE_DIR@"
-  INSTALL_DIR
-  "@HUNTER_PACKAGE_INSTALL_PREFIX@"
-      # not used, just avoid creating Install/<name> empty directory
-  CONFIGURE_COMMAND
-  ${env_cmd}
-  ${copy_mpi_command}
-  COMMAND
-  ${bootstrap_cmd}
-  BUILD_COMMAND
-  ${b2_cmd}
-  ${verbose_output}
-  ${build_opts}
-  BUILD_IN_SOURCE
-  1
-  INSTALL_COMMAND
-  ${b2_cmd}
-  -d0
-  ${build_opts}
-  stage # install only libraries, headers installed in `url_sha1_boost`
-  "--stagedir=@HUNTER_PACKAGE_INSTALL_PREFIX@"
-  # Logging as Workaround for VS_UNICODE_OUTPUT issue:
-  # https://public.kitware.com/Bug/view.php?id=14266
-  LOG_CONFIGURE 1
-  LOG_BUILD 1
-  LOG_INSTALL 1
+    "@HUNTER_EP_NAME@"
+    URL
+    @HUNTER_PACKAGE_URL@
+    URL_HASH
+    SHA1=@HUNTER_PACKAGE_SHA1@
+    DOWNLOAD_DIR
+    "@HUNTER_PACKAGE_DOWNLOAD_DIR@"
+    SOURCE_DIR
+    "@HUNTER_PACKAGE_SOURCE_DIR@"
+    INSTALL_DIR
+    "@HUNTER_PACKAGE_INSTALL_PREFIX@"
+        # not used, just avoid creating Install/<name> empty directory
+    CONFIGURE_COMMAND
+    ${env_cmd}
+    ${copy_mpi_command}
+    COMMAND
+    ${bootstrap_cmd}
+    BUILD_COMMAND
+    ${b2_cmd}
+    ${verbose_output}
+    ${build_opts}
+    BUILD_IN_SOURCE
+    1
+    INSTALL_COMMAND
+    ${b2_cmd}
+    -d0
+    ${build_opts}
+    stage # install only libraries, headers installed in `url_sha1_boost`
+    "--stagedir=@HUNTER_PACKAGE_INSTALL_PREFIX@"
+    # Logging as Workaround for VS_UNICODE_OUTPUT issue:
+    # https://public.kitware.com/Bug/view.php?id=14266
+    LOG_CONFIGURE 1
+    LOG_BUILD 1
+    LOG_INSTALL 1
 )
 
 # Forward some variables

--- a/cmake/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/schemes/url_sha1_boost_library.cmake.in
@@ -217,8 +217,9 @@ else()
 endif()
 
 set(toolset_full_name ${toolset_name})
-if (toolset_version)
-  set(toolset_full_name ${toolset_full_name}-${toolset_version})
+string(COMPARE NOTEQUAL "${toolset_version}" "" has_toolset_version)
+if (has_toolset_version)
+  set(toolset_full_name ${toolset_name}-${toolset_version})
 endif()
 set(
     build_opts
@@ -233,9 +234,9 @@ set(
 )
 
 hunter_boost_component_b2_args(
-    "@HUNTER_PACKAGE_COMPONENT@"
-    "@HUNTER_Boost_CMAKE_ARGS@"
-    b2_component_opts
+  "@HUNTER_PACKAGE_COMPONENT@"
+  "@HUNTER_Boost_CMAKE_ARGS@"
+  b2_component_opts
 )
 
 list(APPEND build_opts ${b2_component_opts})

--- a/cmake/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/schemes/url_sha1_boost_library.cmake.in
@@ -102,6 +102,23 @@ else()
   hunter_fatal_error("TODO: set toolset for boost" WIKI "error.boost.toolset")
 endif()
 
+if("@ANDROID@")
+  set(toolset_version ndk)
+endif()
+
+get_directory_property(defs COMPILE_DEFINITIONS)
+foreach(def ${defs})
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D${def}")
+endforeach()
+
+get_directory_property(include_dirs INCLUDE_DIRECTORIES)
+foreach(include_dir ${include_dirs})
+  set(
+      CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS} ${CMAKE_INCLUDE_SYSTEM_FLAG_CXX} ${include_dir}"
+  )
+endforeach()
+
 if("@MSVC@")
   set(env_cmd "@HUNTER_MSVC_VCVARSALL@" "@HUNTER_MSVC_ARCH@")
 else()
@@ -163,8 +180,10 @@ set(boost_user_jam "@HUNTER_PACKAGE_BUILD_DIR@/boost.user.jam")
 file(
      WRITE
      ${boost_user_jam}
-     "using ${toolset_name} :\n"
+     "using ${toolset_name}\n"
+     "    : ${toolset_version}\n"
      "    : \"${boost_compiler}\"\n"
+     "    : <archiver> \"${CMAKE_AR}\"\n"
      ";\n"
      "${using_mpi}\n"
 )
@@ -192,6 +211,10 @@ else()
   set(link_opts link=static)
 endif()
 
+set(toolset_full_name ${toolset_name})
+if (toolset_version)
+  set(toolset_full_name ${toolset_full_name}-${toolset_version})
+endif()
 set(
     build_opts
     -a
@@ -199,7 +222,7 @@ set(
     threading=multi
     ${variants}
     --layout=tagged
-    toolset=${toolset_name}
+    toolset=${toolset_full_name}
     "--user-config=${boost_user_jam}"
     --with-@HUNTER_PACKAGE_COMPONENT@
 )
@@ -242,9 +265,9 @@ else()
   set(b2_cmd "./b2")
 endif()
 
-file(READ "${boost_user_jam}" USER_JAM_CONTENT)
 
 if(HUNTER_STATUS_DEBUG)
+file(READ "${boost_user_jam}" USER_JAM_CONTENT)
   hunter_status_debug("Build options:")
   foreach(opt ${build_opts})
     hunter_status_debug("  ${opt}")

--- a/cmake/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/schemes/url_sha1_boost_library.cmake.in
@@ -90,34 +90,39 @@ endif()
 
 string(COMPARE EQUAL "@CMAKE_CXX_COMPILER_ID@" "Clang" compiler_is_clang)
 
-if("@APPLE@")
-  set(toolset_name darwin)
+if("@ANDROID@")
+  set(toolset_name "gcc")
+  set(toolset_version "ndk")
+elseif("@APPLE@")
+  set(toolset_name "darwin")
+  set(toolset_version "")
 elseif("@CMAKE_COMPILER_IS_GNUCXX@")
-  set(toolset_name gcc)
+  set(toolset_name "gcc")
+  set(toolset_version "")
 elseif(compiler_is_clang)
-  set(toolset_name clang)
+  set(toolset_name "clang")
+  set(toolset_version "")
 elseif("@MSVC@")
-  set(toolset_name msvc)
+  set(toolset_name "msvc")
+  set(toolset_version "")
 else()
   hunter_fatal_error("TODO: set toolset for boost" WIKI "error.boost.toolset")
 endif()
 
 if("@ANDROID@")
-  set(toolset_version ndk)
-endif()
-
-get_directory_property(defs COMPILE_DEFINITIONS)
-foreach(def ${defs})
+  get_directory_property(defs COMPILE_DEFINITIONS)
+  foreach(def ${defs})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D${def}")
-endforeach()
-
-get_directory_property(include_dirs INCLUDE_DIRECTORIES)
-foreach(include_dir ${include_dirs})
-  set(
+  endforeach()
+  
+  get_directory_property(include_dirs INCLUDE_DIRECTORIES)
+  foreach(include_dir ${include_dirs})
+    set(
       CMAKE_CXX_FLAGS
       "${CMAKE_CXX_FLAGS} ${CMAKE_INCLUDE_SYSTEM_FLAG_CXX} ${include_dir}"
-  )
-endforeach()
+    )
+  endforeach()
+endif()
 
 if("@MSVC@")
   set(env_cmd "@HUNTER_MSVC_VCVARSALL@" "@HUNTER_MSVC_ARCH@")
@@ -140,33 +145,33 @@ if(is_mpi)
     if(NOT MPI_CXX_FOUND)
       # Fix concurrent output to console
       execute_process(
-          COMMAND
-          "@CMAKE_COMMAND@"
-          -E
-          echo
-          "MPI is required. Please install it. For example MS-MPI: "
-          "http://msdn.microsoft.com/en-us/library/bb524831%28v=vs.85%29.aspx"
+        COMMAND
+        "@CMAKE_COMMAND@"
+        -E
+        echo
+        "MPI is required. Please install it. For example MS-MPI: "
+        "http://msdn.microsoft.com/en-us/library/bb524831%28v=vs.85%29.aspx"
       )
       hunter_fatal_error("MPI is required" WIKI "error.boost.mpi.on.windows")
     endif()
     get_filename_component(MPI_DIR "${MPI_CXX_INCLUDE_PATH}/.." ABSOLUTE)
     string(REPLACE "/" "\\\\" MPI_DIR "${MPI_DIR}")
     configure_file(
-        "@HUNTER_SELF@/scripts/mpi.jam"
-        "@HUNTER_PACKAGE_BUILD_DIR@/tools/build/v2/tools/mpi.jam"
+      "@HUNTER_SELF@/scripts/mpi.jam"
+      "@HUNTER_PACKAGE_BUILD_DIR@/tools/build/v2/tools/mpi.jam"
     )
 
     # HUNTER_PACKAGE_SOURCE_DIR will be removed while unpacking. Save mpi.jam
     # in HUNTER_PACKAGE_BUILD_DIR first and move it to HUNTER_PACKAGE_SOURCE_DIR
     # on configure step
     set(
-        copy_mpi_command
-        COMMAND
-        "@CMAKE_COMMAND@"
-        -E
-        copy
-        "@HUNTER_PACKAGE_BUILD_DIR@/tools/build/v2/tools/mpi.jam"
-        "@HUNTER_PACKAGE_SOURCE_DIR@/tools/build/v2/tools/mpi.jam"
+      copy_mpi_command
+      COMMAND
+      "@CMAKE_COMMAND@"
+      -E
+      copy
+      "@HUNTER_PACKAGE_BUILD_DIR@/tools/build/v2/tools/mpi.jam"
+      "@HUNTER_PACKAGE_SOURCE_DIR@/tools/build/v2/tools/mpi.jam"
     )
   endif()
   set(variants variant=release) # build bug
@@ -178,14 +183,14 @@ endif()
 
 set(boost_user_jam "@HUNTER_PACKAGE_BUILD_DIR@/boost.user.jam")
 file(
-     WRITE
-     ${boost_user_jam}
-     "using ${toolset_name}\n"
-     "    : ${toolset_version}\n"
-     "    : \"${boost_compiler}\"\n"
-     "    : <archiver> \"${CMAKE_AR}\"\n"
-     ";\n"
-     "${using_mpi}\n"
+  WRITE
+  ${boost_user_jam}
+  "using ${toolset_name}\n"
+  "  : ${toolset_version}\n"
+  "  : \"${boost_compiler}\"\n"
+  "  : <archiver> \"${CMAKE_AR}\"\n"
+  ";\n"
+  "${using_mpi}\n"
 )
 
 if("@MSVC@")
@@ -216,22 +221,22 @@ if (toolset_version)
   set(toolset_full_name ${toolset_full_name}-${toolset_version})
 endif()
 set(
-    build_opts
-    -a
-    ${link_opts}
-    threading=multi
-    ${variants}
-    --layout=tagged
-    toolset=${toolset_full_name}
-    "--user-config=${boost_user_jam}"
-    --with-@HUNTER_PACKAGE_COMPONENT@
+  build_opts
+  -a
+  ${link_opts}
+  threading=multi
+  ${variants}
+  --layout=tagged
+  toolset=${toolset_full_name}
+  "--user-config=${boost_user_jam}"
+  --with-@HUNTER_PACKAGE_COMPONENT@
 )
 
 hunter_boost_component_b2_args(
   "@HUNTER_PACKAGE_COMPONENT@"
   "@HUNTER_Boost_CMAKE_ARGS@"
   b2_component_opts
-  )
+)
 
 list(APPEND build_opts ${b2_component_opts})
 
@@ -267,7 +272,7 @@ endif()
 
 
 if(HUNTER_STATUS_DEBUG)
-file(READ "${boost_user_jam}" USER_JAM_CONTENT)
+  file(READ "${boost_user_jam}" USER_JAM_CONTENT)
   hunter_status_debug("Build options:")
   foreach(opt ${build_opts})
     hunter_status_debug("  ${opt}")
@@ -280,40 +285,40 @@ file(READ "${boost_user_jam}" USER_JAM_CONTENT)
 endif()
 
 ExternalProject_Add(
-    "@HUNTER_EP_NAME@"
-    URL
-    @HUNTER_PACKAGE_URL@
-    URL_HASH
-    SHA1=@HUNTER_PACKAGE_SHA1@
-    DOWNLOAD_DIR
-    "@HUNTER_PACKAGE_DOWNLOAD_DIR@"
-    SOURCE_DIR
-    "@HUNTER_PACKAGE_SOURCE_DIR@"
-    INSTALL_DIR
-    "@HUNTER_PACKAGE_INSTALL_PREFIX@"
-        # not used, just avoid creating Install/<name> empty directory
-    CONFIGURE_COMMAND
-    ${env_cmd}
-    ${copy_mpi_command}
-    COMMAND
-    ${bootstrap_cmd}
-    BUILD_COMMAND
-    ${b2_cmd}
-    ${verbose_output}
-    ${build_opts}
-    BUILD_IN_SOURCE
-    1
-    INSTALL_COMMAND
-    ${b2_cmd}
-    -d0
-    ${build_opts}
-    stage # install only libraries, headers installed in `url_sha1_boost`
-    "--stagedir=@HUNTER_PACKAGE_INSTALL_PREFIX@"
-    # Logging as Workaround for VS_UNICODE_OUTPUT issue:
-    # https://public.kitware.com/Bug/view.php?id=14266
-    LOG_CONFIGURE 1
-    LOG_BUILD 1
-    LOG_INSTALL 1
+  "@HUNTER_EP_NAME@"
+  URL
+  @HUNTER_PACKAGE_URL@
+  URL_HASH
+  SHA1=@HUNTER_PACKAGE_SHA1@
+  DOWNLOAD_DIR
+  "@HUNTER_PACKAGE_DOWNLOAD_DIR@"
+  SOURCE_DIR
+  "@HUNTER_PACKAGE_SOURCE_DIR@"
+  INSTALL_DIR
+  "@HUNTER_PACKAGE_INSTALL_PREFIX@"
+      # not used, just avoid creating Install/<name> empty directory
+  CONFIGURE_COMMAND
+  ${env_cmd}
+  ${copy_mpi_command}
+  COMMAND
+  ${bootstrap_cmd}
+  BUILD_COMMAND
+  ${b2_cmd}
+  ${verbose_output}
+  ${build_opts}
+  BUILD_IN_SOURCE
+  1
+  INSTALL_COMMAND
+  ${b2_cmd}
+  -d0
+  ${build_opts}
+  stage # install only libraries, headers installed in `url_sha1_boost`
+  "--stagedir=@HUNTER_PACKAGE_INSTALL_PREFIX@"
+  # Logging as Workaround for VS_UNICODE_OUTPUT issue:
+  # https://public.kitware.com/Bug/view.php?id=14266
+  LOG_CONFIGURE 1
+  LOG_BUILD 1
+  LOG_INSTALL 1
 )
 
 # Forward some variables


### PR DESCRIPTION
Compiled boost static libs under MacOSX 10.9.4 with toolchains:
  Android NDK r10e
  Default Xcode 6.1.1 (Apple LLVM version 6.0 (clang-600.0.56)

NOTE: we are changing CMAKE_CXX_FLAGS by adding the contents of `include_directories(SYSTEM ...)` and `add_definitions(...)`, but since Boost compilation runs in a child CMake script, the application won't have any duplicate flags. I don't know if relying on the behavior that it runs on child CMake script can bring any drawbacks in the future.