### PR TITLE
Adding sparsehash/ package

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -64,6 +64,7 @@ hunter_config(PNG VERSION 1.6.16-p3)
 hunter_config(RapidJSON VERSION 0.11-hunter)
 hunter_config(Sober VERSION 0.1.1) # Relax warnings
 hunter_config(Sources-for-Android-SDK VERSION 21) # API 21
+hunter_config(sparsehash VERSION 2.0.2)
 hunter_config(Sugar VERSION 1.2.2)
 hunter_config(TIFF VERSION 4.0.2-p3)
 hunter_config(Washer VERSION 0.1.2)

--- a/cmake/projects/sparsehash/hunter.cmake
+++ b/cmake/projects/sparsehash/hunter.cmake
@@ -1,0 +1,34 @@
+#
+# hunter.cmake for sparsehash/
+#
+# Copyright 2015, Aaditya Kalsi
+#
+
+if(DEFINED HUNTER_CMAKE_PROJECTS_SPARSEHASH_HUNTER_CMAKE_)
+  return()
+else()
+  set(HUNTER_CMAKE_PROJECTS_SPARSEHASH_HUNTER_CMAKE_ 1)
+endif()
+
+# Load modules used
+include(hunter_add_version)
+include(hunter_download)
+include(hunter_pick_scheme)
+
+# Version list
+hunter_add_version(
+  PACKAGE_NAME
+  sparsehash
+  VERSION
+  "2.0.2"
+  URL
+  https://github.com/aadityakalsi/sparsehash/archive/sparsehash-2.0.2-cmake.tar.gz
+  SHA1
+  8fa7190fa2ad43218f91717be0bf151667773263
+)
+
+# Default CMake scheme
+hunter_pick_scheme(DEFAULT url_sha1_cmake)
+
+# This is header-only, so only headers are needed
+hunter_download(PACKAGE_NAME sparsehash)


### PR DESCRIPTION
I probably have to fix this ```hunter.cmake```, since this is header only, and we don't need ```Release``` and ```Debug``` variants.

Other than that, I think this works well.

Sparsehash has BSD 3 clause license, so the license will have to go along with the source wherever used.