### PR TITLE
Autotools parallel build with HUNTER_JOBS_OPTION

### DIFF
--- a/cmake/schemes/url_sha1_autotools.cmake.in
+++ b/cmake/schemes/url_sha1_autotools.cmake.in
@@ -40,6 +40,13 @@ set(
 )
 set(build_command . "@HUNTER_SELF@/scripts/clear-all.sh" && make)
 
+set(build_opts)
+string(COMPARE NOTEQUAL "@HUNTER_JOBS_OPTION@" "" have_jobs)
+if(have_jobs)
+  list(APPEND build_opts "-j" "@HUNTER_JOBS_OPTION@")
+endif()
+
+
 ExternalProject_Add(
     "@HUNTER_EP_NAME@"
     URL
@@ -59,6 +66,7 @@ ExternalProject_Add(
     "--prefix=@HUNTER_PACKAGE_INSTALL_PREFIX@"
     BUILD_COMMAND
     ${build_command}
+    ${build_opts}
     BUILD_IN_SOURCE
     1
     INSTALL_COMMAND

--- a/cmake/schemes/url_sha1_odb-sqlite_autotools.cmake.in
+++ b/cmake/schemes/url_sha1_odb-sqlite_autotools.cmake.in
@@ -53,6 +53,13 @@ set(
 )
 set(build_command . "@HUNTER_SELF@/scripts/clear-all.sh" && make)
 
+set(build_opts)
+string(COMPARE NOTEQUAL "@HUNTER_JOBS_OPTION@" "" have_jobs)
+if(have_jobs)
+  list(APPEND build_opts "-j" "@HUNTER_JOBS_OPTION@")
+endif()
+
+
 ExternalProject_Add(
     "@HUNTER_EP_NAME@"
     URL
@@ -72,6 +79,7 @@ ExternalProject_Add(
     "--prefix=@HUNTER_PACKAGE_INSTALL_PREFIX@"
     BUILD_COMMAND
     ${build_command}
+    ${build_opts}
     BUILD_IN_SOURCE
     1
     INSTALL_COMMAND


### PR DESCRIPTION
I just noticed while working on the Qt project that I was not calling `make` with the `-j ${HUNTER_JOBS_OPTION}`.

So I updated the autotools to use it. However Qt and Autotools based project are calling this `make` command. I will have to think of a way to avoid this repetition.