### PR TITLE
qtquickcontrols fully depends on qtdeclarative

### DIFF
--- a/scripts/qt-configure.cmake.in
+++ b/scripts/qt-configure.cmake.in
@@ -54,6 +54,7 @@ set(
     qtgraphicaleffects
     qtlocation
     qtmultimedia
+    qtquickcontrols
     qtsensors
     qtwebchannel
     qtwebkit


### PR DESCRIPTION
qtquickcontrols fully depends on qtdeclarative