### PR TITLE
Fixed MSVC architecture detection regular expression

### DIFF
--- a/cmake/modules/hunter_setup_msvc_arch.cmake
+++ b/cmake/modules/hunter_setup_msvc_arch.cmake
@@ -49,7 +49,7 @@ macro(hunter_setup_msvc_arch)
     string(
         REGEX
         REPLACE
-        "^[1-9]"
+        "^[0-9]"
         ""
         HUNTER_MSVC_ARCH
         "${HUNTER_MSVC_ARCH}"


### PR DESCRIPTION
MSVC regular expression doesn't account for the remaining '0' when
parsing "Visual Studio 10 2010..". The 3rd regex remove [1-9] where it
should be [0-9] as above comment shows the remaining '0'