### PR TITLE
add latest version of armadillo library

### DIFF
--- a/cmake/projects/Armadillo/hunter.cmake
+++ b/cmake/projects/Armadillo/hunter.cmake
@@ -1,0 +1,23 @@
+if(DEFINED HUNTER_CMAKE_PROJECTS_ARMADILLO_HUNTER_CMAKE_)
+	return()
+else()
+	set(HUNTER_CMAKE_PROJECTS_ARMADILLO_HUNTER_CMAKE_ 1)
+endif()
+
+include(hunter_add_version)
+include(hunter_download)
+include(hunter_pick_scheme)
+
+hunter_add_version(
+	PACKAGE_NAME
+	armadillo
+	VERSION
+	"5.600.2"
+	URL
+	"https://github.com/thomasfeher/armadillo/archive/v5.600.2.tar.gz"
+	SHA1
+	2cb74a9228ffe9ccf4b48d7cccf344365867020b
+	)
+
+hunter_pick_scheme(DEFAULT url_sha1_armadillo) # Use new custom scheme
+hunter_download(PACKAGE_NAME armadillo)

--- a/cmake/schemes/url_sha1_armadillo.cmake.in
+++ b/cmake/schemes/url_sha1_armadillo.cmake.in
@@ -1,0 +1,49 @@
+# This is configuration file, variable @SOME_VARIABLE_NAME@ will be substituted during configure_file command
+cmake_minimum_required(VERSION 3.0)
+
+# If such variables like `CMAKE_CXX_FLAGS` or `CMAKE_CXX_COMPILER` not used by scheme
+# setting `LANGUAGES` to `NONE` will speed-up build a little bit. If you have any problems/glitches
+# use regular `project(Hunter)` command
+project(Hunter LANGUAGES NONE)
+
+include(ExternalProject) # ExternalProject_Add
+
+# some Hunter modules will be used
+list(APPEND CMAKE_MODULE_PATH "@HUNTER_SELF@/cmake/modules")
+
+include(hunter_status_debug)
+include(hunter_test_string_not_empty)
+
+# print this message if HUNTER_STATUS_DEBUG option is ON
+hunter_status_debug("Scheme: url_sha1_armadillo")
+
+# Check variables is not empty
+hunter_test_string_not_empty("@HUNTER_SELF@")
+hunter_test_string_not_empty("@HUNTER_EP_NAME@")
+hunter_test_string_not_empty("@HUNTER_PACKAGE_URL@")
+hunter_test_string_not_empty("@HUNTER_PACKAGE_SHA1@")
+hunter_test_string_not_empty("@HUNTER_PACKAGE_DOWNLOAD_DIR@")
+hunter_test_string_not_empty("@HUNTER_PACKAGE_SOURCE_DIR@")
+hunter_test_string_not_empty("@HUNTER_INSTALL_PREFIX@")
+
+ExternalProject_Add(
+	@HUNTER_EP_BASE@ # Name of the external project. Actually not used set for beautify logging messages
+	URL
+	@HUNTER_PACKAGE_URL@ # URL of the package to download
+	URL_HASH
+	SHA1=@HUNTER_PACKAGE_SHA1@ # SHA1 hash
+	DOWNLOAD_DIR
+	"@HUNTER_PACKAGE_DOWNLOAD_DIR@" # Archive destination location
+	SOURCE_DIR
+	"@HUNTER_PACKAGE_SOURCE_DIR@" # Unpack directory
+	INSTALL_DIR
+	"@HUNTER_INSTALL_PREFIX@" # not used actually (see install command)
+	CONFIGURE_COMMAND
+	""
+	BUILD_COMMAND
+	""
+	BUILD_IN_SOURCE
+	1
+	INSTALL_COMMAND
+	"@CMAKE_COMMAND@" -E copy_directory "include" "${CMAKE_INSTALL_PREFIX}/include/"
+	)


### PR DESCRIPTION
Does not use the build-in cmake files because they are ment to build a
convenience library that automatically determines installed dependencies
and links those.
This would prevent the possibility to install those dependencies via
hunter, because the cmake script would not find them. (Right??)

I will add older versions later.

Should the Armadillo repository be transferred to https://github.com/hunter-packages ?