### PR TITLE
Add License management to Hunter

### DIFF
--- a/cmake/modules/hunter_download.cmake
+++ b/cmake/modules/hunter_download.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2015, Ruslan Baratov
+# Copyright (c) 2013-2015, Ruslan Baratov, Aaditya Kalsi
 # All rights reserved.
 
 include(CMakeParseArguments) # cmake_parse_arguments
@@ -178,9 +178,16 @@ function(hunter_download)
     endif()
   endif()
 
+  # license file variable
+  set(HUNTER_PACKAGE_LICENSE_FILE "${HUNTER_PACKAGE_INSTALL_PREFIX}/licenses/${HUNTER_PACKAGE_NAME}/LICENSE")
+  set(license_var "${HUNTER_PACKAGE_NAME}_LICENSE")
+  set(license_val "${HUNTER_INSTALL_PREFIX}/licenses/${HUNTER_PACKAGE_NAME}/LICENSE")
+
   set(${root_name} "${${root_name}}" PARENT_SCOPE)
   set(ENV{${root_name}} "${${root_name}}")
   hunter_status_print("${root_name}: ${${root_name}} (ver.: ${ver})")
+
+  set(${license_var} ${license_val} PARENT_SCOPE)
 
   # temp toolchain file to set variables and include real toolchain
   set(HUNTER_DOWNLOAD_TOOLCHAIN "${HUNTER_PACKAGE_HOME_DIR}/toolchain.cmake")

--- a/cmake/schemes/url_sha1_boost.cmake.in
+++ b/cmake/schemes/url_sha1_boost.cmake.in
@@ -26,6 +26,7 @@ hunter_test_string_not_empty("@HUNTER_PACKAGE_DOWNLOAD_DIR@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_SOURCE_DIR@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_INSTALL_PREFIX@")
 hunter_test_string_not_empty("@HUNTER_Boost_VERSION@")
+hunter_test_string_not_empty("@HUNTER_PACKAGE_LICENSE_FILE@")
 if("@MSVC@")
   hunter_test_string_not_empty("@HUNTER_MSVC_ARCH@")
   hunter_test_string_not_empty("@HUNTER_MSVC_VCVARSALL@")
@@ -139,6 +140,12 @@ ExternalProject_Add(
     ${boost_list}
     "--prefix=@HUNTER_PACKAGE_INSTALL_PREFIX@"
     ${log_opts}
+    COMMAND # Copy license files
+    "@CMAKE_COMMAND@"
+    "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
+    "-Ddstfile=@HUNTER_PACKAGE_LICENSE_FILE@"
+    -P
+    "@HUNTER_SELF@/scripts/try-copy-license.cmake"
 )
 
 # Forward some variables

--- a/cmake/schemes/url_sha1_cmake.cmake.in
+++ b/cmake/schemes/url_sha1_cmake.cmake.in
@@ -125,14 +125,14 @@ foreach(configuration @HUNTER_PACKAGE_CONFIGURATION_TYPES@)
           --config ${configuration}
           --
           ${jobs_option}
+        COMMAND # Copy license files
+          "@CMAKE_COMMAND@"
+          "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
+          "-Ddstfile=@HUNTER_PACKAGE_LICENSE_FILE@"
+          -P
+          "@HUNTER_SELF@/scripts/try-copy-license.cmake"
       LOG_BUILD ${log_build}
       LOG_INSTALL ${log_install}
-      COMMAND # Copy license files
-      "@CMAKE_COMMAND@"
-      "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
-      "-Ddstfile=@HUNTER_PACKAGE_LICENSE_FILE@"
-      -P
-      "@HUNTER_SELF@/scripts/try-copy-license.cmake"
   )
 
   # Each external project must depends on previous one since they all use

--- a/cmake/schemes/url_sha1_cmake.cmake.in
+++ b/cmake/schemes/url_sha1_cmake.cmake.in
@@ -34,6 +34,7 @@ hunter_test_string_not_empty("@HUNTER_PACKAGE_INSTALL_PREFIX@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_CONFIGURATION_TYPES@")
 hunter_test_string_not_empty("@HUNTER_CACHE_FILE@")
 hunter_test_string_not_empty("@HUNTER_ARGS_FILE@")
+hunter_test_string_not_empty("@HUNTER_PACKAGE_LICENSE_FILE@")
 hunter_test_string_not_empty("@CMAKE_GENERATOR@")
 hunter_test_string_not_empty("${CMAKE_TOOLCHAIN_FILE}")
 
@@ -126,6 +127,12 @@ foreach(configuration @HUNTER_PACKAGE_CONFIGURATION_TYPES@)
           ${jobs_option}
       LOG_BUILD ${log_build}
       LOG_INSTALL ${log_install}
+      COMMAND # Copy license files
+      "@CMAKE_COMMAND@"
+      "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
+      "-Ddstfile=@HUNTER_PACKAGE_LICENSE_FILE@"
+      -P
+      "@HUNTER_SELF@/scripts/try-copy-license.cmake"
   )
 
   # Each external project must depends on previous one since they all use

--- a/cmake/schemes/url_sha1_ios_sim.cmake.in
+++ b/cmake/schemes/url_sha1_ios_sim.cmake.in
@@ -22,6 +22,7 @@ hunter_test_string_not_empty("@HUNTER_PACKAGE_SHA1@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_DOWNLOAD_DIR@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_SOURCE_DIR@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_INSTALL_PREFIX@")
+hunter_test_string_not_empty("@HUNTER_PACKAGE_LICENSE_FILE@")
 
 string(COMPARE NOTEQUAL "@HUNTER_JOBS_OPTION@" "" have_jobs)
 if(have_jobs)
@@ -66,4 +67,10 @@ ExternalProject_Add(
     1
     INSTALL_COMMAND
     "@CMAKE_COMMAND@" -E copy build/Release/ios-sim "@HUNTER_PACKAGE_INSTALL_PREFIX@"
+    COMMAND # Copy license files
+    "@CMAKE_COMMAND@"
+    "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
+    "-Ddstfile=@HUNTER_PACKAGE_LICENSE_FILE@"
+    -P
+    "@HUNTER_SELF@/scripts/try-copy-license.cmake"
 )

--- a/cmake/schemes/url_sha1_odb-sqlite_autotools.cmake.in
+++ b/cmake/schemes/url_sha1_odb-sqlite_autotools.cmake.in
@@ -57,5 +57,11 @@ hunter_autotools_project("@HUNTER_EP_NAME@"
       "-I${ODB_INCLUDE_DIR} -I${SQLITE3_INCLUDE_DIR}"
     LDFLAGS
       "-L${ODB_LIB_DIR} -lodb -L${SQLITE3_LIB_DIR} -lsqlite3"
+    COMMAND # Copy license files
+    "@CMAKE_COMMAND@"
+    "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
+    "-Ddstfile=@HUNTER_PACKAGE_LICENSE_FILE@"
+    -P
+    "@HUNTER_SELF@/scripts/try-copy-license.cmake"
 )
 

--- a/cmake/schemes/url_sha1_odb-sqlite_autotools.cmake.in
+++ b/cmake/schemes/url_sha1_odb-sqlite_autotools.cmake.in
@@ -57,11 +57,4 @@ hunter_autotools_project("@HUNTER_EP_NAME@"
       "-I${ODB_INCLUDE_DIR} -I${SQLITE3_INCLUDE_DIR}"
     LDFLAGS
       "-L${ODB_LIB_DIR} -lodb -L${SQLITE3_LIB_DIR} -lsqlite3"
-    COMMAND # Copy license files
-    "@CMAKE_COMMAND@"
-    "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
-    "-Ddstfile=@HUNTER_PACKAGE_LICENSE_FILE@"
-    -P
-    "@HUNTER_SELF@/scripts/try-copy-license.cmake"
 )
-

--- a/cmake/schemes/url_sha1_openssl.cmake.in
+++ b/cmake/schemes/url_sha1_openssl.cmake.in
@@ -23,6 +23,7 @@ hunter_test_string_not_empty("@HUNTER_PACKAGE_SHA1@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_DOWNLOAD_DIR@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_SOURCE_DIR@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_INSTALL_PREFIX@")
+hunter_test_string_not_empty("@HUNTER_PACKAGE_LICENSE_FILE@")
 
 if(APPLE)
   set(configure_command "./Configure")
@@ -64,4 +65,10 @@ ExternalProject_Add(
     make install_sw
     # Install without documentation
     # * https://github.com/openssl/openssl/issues/57
+    COMMAND # Copy license files
+    "@CMAKE_COMMAND@"
+    "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
+    "-Ddstfile=@HUNTER_PACKAGE_LICENSE_FILE@"
+    -P
+    "@HUNTER_SELF@/scripts/try-copy-license.cmake"
 )

--- a/cmake/schemes/url_sha1_openssl_ios.cmake.in
+++ b/cmake/schemes/url_sha1_openssl_ios.cmake.in
@@ -138,12 +138,6 @@ foreach(variant @IPHONEOS_ARCHS@ @IPHONESIMULATOR_ARCHS@)
       make install_sw
           # installed libraries will be rewrited,
           # other files are equal
-      COMMAND # Copy license files
-      "@CMAKE_COMMAND@"
-      "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
-      "-Ddstfile=@HUNTER_PACKAGE_LICENSE_FILE@"
-      -P
-      "@HUNTER_SELF@/scripts/try-copy-license.cmake"
   )
 
   add_dependencies(

--- a/cmake/schemes/url_sha1_openssl_ios.cmake.in
+++ b/cmake/schemes/url_sha1_openssl_ios.cmake.in
@@ -24,6 +24,7 @@ hunter_test_string_not_empty("@HUNTER_PACKAGE_SHA1@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_DOWNLOAD_DIR@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_SOURCE_DIR@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_INSTALL_PREFIX@")
+hunter_test_string_not_empty("@HUNTER_PACKAGE_LICENSE_FILE@")
 # Note: support for single architecture/native iOS builds (i.e., arm64)
 hunter_test_string_not_empty("@IPHONEOS_ARCHS@@IPHONESIMULATOR_ARCHS@")
 hunter_test_string_not_empty("@IOS_SDK_VERSION@")
@@ -74,6 +75,12 @@ ExternalProject_Add(
     ${crypto_input_libraries}
     -o
     "@HUNTER_PACKAGE_INSTALL_PREFIX@/lib/libcrypto.a"
+    COMMAND # Copy license files
+    "@CMAKE_COMMAND@"
+    "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
+    "-Ddstfile=@HUNTER_PACKAGE_LICENSE_FILE@"
+    -P
+    "@HUNTER_SELF@/scripts/try-copy-license.cmake"
 )
 
 foreach(variant @IPHONEOS_ARCHS@ @IPHONESIMULATOR_ARCHS@)
@@ -131,6 +138,12 @@ foreach(variant @IPHONEOS_ARCHS@ @IPHONESIMULATOR_ARCHS@)
       make install_sw
           # installed libraries will be rewrited,
           # other files are equal
+      COMMAND # Copy license files
+      "@CMAKE_COMMAND@"
+      "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
+      "-Ddstfile=@HUNTER_PACKAGE_LICENSE_FILE@"
+      -P
+      "@HUNTER_SELF@/scripts/try-copy-license.cmake"
   )
 
   add_dependencies(

--- a/cmake/schemes/url_sha1_openssl_windows.cmake.in
+++ b/cmake/schemes/url_sha1_openssl_windows.cmake.in
@@ -27,6 +27,7 @@ hunter_test_string_not_empty("@HUNTER_PACKAGE_SOURCE_DIR@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_INSTALL_PREFIX@")
 hunter_test_string_not_empty("@HUNTER_MSVC_ARCH@")
 hunter_test_string_not_empty("@HUNTER_MSVC_VCVARSALL@")
+hunter_test_string_not_empty("@HUNTER_PACKAGE_LICENSE_FILE@")
 
 # `find_package(Perl)` is not suitable because `perl` from
 # cygwin directory can be found
@@ -89,4 +90,10 @@ ExternalProject_Add(
     INSTALL_COMMAND
     COMMAND
     nmake -f "ms\\nt.mak" install
+    COMMAND # Copy license files
+    "@CMAKE_COMMAND@"
+    "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
+    "-Ddstfile=@HUNTER_PACKAGE_LICENSE_FILE@"
+    -P
+    "@HUNTER_SELF@/scripts/try-copy-license.cmake"
 )

--- a/cmake/schemes/url_sha1_qt.cmake.in
+++ b/cmake/schemes/url_sha1_qt.cmake.in
@@ -334,12 +334,12 @@ ExternalProject_Add(
         "${qt_source_dir}/qt-install.cmake"
     COMMAND
         "@CMAKE_COMMAND@" -P "${qt_source_dir}/qt-install.cmake"
-    LOG_BUILD ${log_build}
-    LOG_INSTALL ${log_install}
     COMMAND # Copy license files
       "@CMAKE_COMMAND@"
       "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
       "-Ddstfile=@HUNTER_PACKAGE_LICENSE_FILE@"
       -P
       "@HUNTER_SELF@/scripts/try-copy-license.cmake"
+    LOG_BUILD ${log_build}
+    LOG_INSTALL ${log_install}
 )

--- a/cmake/schemes/url_sha1_qt.cmake.in
+++ b/cmake/schemes/url_sha1_qt.cmake.in
@@ -27,6 +27,8 @@ hunter_test_string_not_empty("@HUNTER_PACKAGE_CONFIGURATION_TYPES@")
 hunter_test_string_not_empty("@HUNTER_TOOLCHAIN_ID_PATH@")
 hunter_test_string_not_empty("@HUNTER_INSTALL_PREFIX@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_INSTALL_PREFIX@")
+hunter_test_string_not_empty("@HUNTER_PACKAGE_LICENSE_FILE@")
+
 if("@MSVC@")
   hunter_test_string_not_empty("@HUNTER_MSVC_ARCH@")
   hunter_test_string_not_empty("@HUNTER_MSVC_VCVARSALL@")
@@ -334,4 +336,10 @@ ExternalProject_Add(
         "@CMAKE_COMMAND@" -P "${qt_source_dir}/qt-install.cmake"
     LOG_BUILD ${log_build}
     LOG_INSTALL ${log_install}
+    COMMAND # Copy license files
+      "@CMAKE_COMMAND@"
+      "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
+      "-Ddstfile=@HUNTER_PACKAGE_LICENSE_FILE@"
+      -P
+      "@HUNTER_SELF@/scripts/try-copy-license.cmake"
 )

--- a/cmake/schemes/url_sha1_unpack.cmake.in
+++ b/cmake/schemes/url_sha1_unpack.cmake.in
@@ -32,6 +32,7 @@ hunter_test_string_not_empty("@HUNTER_PACKAGE_URL@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_SHA1@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_DOWNLOAD_DIR@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_SOURCE_DIR@")
+hunter_test_string_not_empty("@HUNTER_PACKAGE_LICENSE_FILE@")
 
 ExternalProject_Add(
     "@HUNTER_EP_NAME@"
@@ -51,4 +52,10 @@ ExternalProject_Add(
     ""
     INSTALL_COMMAND
     ""
+    COMMAND # Copy license files
+    "@CMAKE_COMMAND@"
+    "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
+    "-Ddstfile=@HUNTER_PACKAGE_LICENSE_FILE@"
+    -P
+    "@HUNTER_SELF@/scripts/try-copy-license.cmake"
 )

--- a/cmake/schemes/url_sha1_unpack.cmake.in
+++ b/cmake/schemes/url_sha1_unpack.cmake.in
@@ -52,10 +52,4 @@ ExternalProject_Add(
     ""
     INSTALL_COMMAND
     ""
-    COMMAND # Copy license files
-    "@CMAKE_COMMAND@"
-    "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
-    "-Ddstfile=@HUNTER_PACKAGE_LICENSE_FILE@"
-    -P
-    "@HUNTER_SELF@/scripts/try-copy-license.cmake"
 )

--- a/cmake/schemes/url_sha1_unpack_install.cmake.in
+++ b/cmake/schemes/url_sha1_unpack_install.cmake.in
@@ -20,6 +20,7 @@ hunter_test_string_not_empty("@HUNTER_PACKAGE_SHA1@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_DOWNLOAD_DIR@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_SOURCE_DIR@")
 hunter_test_string_not_empty("@HUNTER_PACKAGE_INSTALL_PREFIX@")
+hunter_test_string_not_empty("@HUNTER_PACKAGE_LICENSE_FILE@")
 
 include(ExternalProject) # ExternalProject_Add
 
@@ -44,4 +45,10 @@ ExternalProject_Add(
     "-Dfrom=@HUNTER_PACKAGE_SOURCE_DIR@"
     "-Dto=@HUNTER_PACKAGE_INSTALL_PREFIX@"
     -P "@HUNTER_SELF@/scripts/copy-files.cmake"
+    COMMAND # Copy license files
+    "@CMAKE_COMMAND@"
+    "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
+    "-Ddstfile=@HUNTER_PACKAGE_LICENSE_FILE@"
+    -P
+    "@HUNTER_SELF@/scripts/try-copy-license.cmake"
 )

--- a/examples/Boost/CMakeLists.txt
+++ b/examples/Boost/CMakeLists.txt
@@ -11,13 +11,30 @@ project(download-boost)
 
 # download boost
 hunter_add_package(Boost)
-message("-- Boost license is located here: ${Boost_LICENSE}")
 
 # now boost can be used
 find_package(Boost CONFIG REQUIRED)
 
 add_executable(foo foo.cpp)
 target_link_libraries(foo Boost::boost)
+
+# Create license with Boost's license under 3rd party
+if(NOT EXISTS "${Boost_LICENSE}")
+  message(FATAL_ERROR "License file not found")
+endif()
+
+file(READ "${Boost_LICENSE}" boost_license_content)
+
+set(project_license "${CMAKE_CURRENT_BINARY_DIR}/LICENSE.txt")
+file(
+    WRITE
+    "${project_license}"
+    "Some info about this project license.\n\n"
+    "== 3rd party licenses ==\n\n"
+    "== Boost ==\n\n"
+    "${boost_license_content}"
+)
+message("Project license: ${project_license}")
 
 # Compatibility mode
 find_package(Boost REQUIRED)

--- a/examples/Boost/CMakeLists.txt
+++ b/examples/Boost/CMakeLists.txt
@@ -11,6 +11,7 @@ project(download-boost)
 
 # download boost
 hunter_add_package(Boost)
+message("-- Boost license is located here: ${Boost_LICENSE}")
 
 # now boost can be used
 find_package(Boost CONFIG REQUIRED)

--- a/scripts/try-copy-license.cmake
+++ b/scripts/try-copy-license.cmake
@@ -1,0 +1,70 @@
+# Copyright (c) 2015 Aaditya Kalsi
+# All rights reserved.
+
+string(COMPARE EQUAL "${srcdir}" "" is_empty)
+if(is_empty)
+  message(FATAL_ERROR "'srcdir' should not be empty")
+endif()
+
+string(COMPARE EQUAL "${dstfile}" "" is_empty)
+if(is_empty)
+  message(FATAL_ERROR "'dstfile' should not be empty")
+endif()
+
+# macro to copy file to a given file name
+# CMake's file(COPY) works for a directory only
+# so we use configure_file() with absolute paths
+# to achieve this.
+macro(copyfileto in out)
+  # For debugging
+  # message("-- copylicense: License found; ${in} -> ${out}")
+  configure_file(${in} ${out} COPYONLY)
+endmacro()
+
+# find the license file to copy
+if(EXISTS "${srcdir}/LICENSE")
+  copyfileto("${srcdir}/LICENSE" ${dstfile})
+  return()
+endif()
+
+if(EXISTS "${srcdir}/LICENSE.txt")
+  copyfileto("${srcdir}/LICENSE.txt" ${dstfile})
+  return()
+endif()
+
+if(EXISTS "${srcdir}/COPYING")
+  copyfileto("${srcdir}/COPYING" ${dstfile})
+  return()
+endif()
+
+if(EXISTS "${srcdir}/COPYING.txt")
+  copyfileto("${srcdir}/COPYING.txt" ${dstfile})
+  return()
+endif()
+
+if(EXISTS "${srcdir}/license")
+  copyfileto("${srcdir}/license" ${dstfile})
+  return()
+endif()
+
+if(EXISTS "${srcdir}/license.txt")
+  copyfileto("${srcdir}/license.txt" ${dstfile})
+  return()
+endif()
+
+if(EXISTS "${srcdir}/copying")
+  copyfileto("${srcdir}/copying" ${dstfile})
+  return()
+endif()
+
+if(EXISTS "${srcdir}/copying.txt")
+  copyfileto("${srcdir}/copying.txt" ${dstfile})
+  return()
+endif()
+
+# last effort; glob LICENSE*
+file(GLOB filelist "${srcdir}/LICENSE*")
+if(filelist)
+  list(GET filelist 0 licfile)
+  copyfileto(${licfile} ${dstfile})
+endif()

--- a/scripts/try-copy-license.cmake
+++ b/scripts/try-copy-license.cmake
@@ -1,6 +1,8 @@
 # Copyright (c) 2015 Aaditya Kalsi
 # All rights reserved.
 
+cmake_minimum_required(VERSION 3.0)
+
 string(COMPARE EQUAL "${srcdir}" "" is_empty)
 if(is_empty)
   message(FATAL_ERROR "'srcdir' should not be empty")
@@ -65,6 +67,18 @@ endif()
 # last effort; glob LICENSE*
 file(GLOB filelist "${srcdir}/LICENSE*")
 if(filelist)
-  list(GET filelist 0 licfile)
-  copyfileto(${licfile} ${dstfile})
+  set(licfile )
+  foreach(el ${filelist})
+    if(NOT IS_DIRECTORY ${el})
+      if(licfile)# if already set, unset and break; too many results
+        set(licfile )
+        break()
+      else()# set licfile to the one found
+        set(licfile ${el})
+      endif()
+    endif()
+  endforeach()
+  if(licfile)
+    copyfileto(${licfile} ${dstfile})
+  endif()
 endif()

--- a/scripts/try-copy-license.cmake
+++ b/scripts/try-copy-license.cmake
@@ -71,8 +71,7 @@ if(filelist)
   foreach(el ${filelist})
     if(NOT IS_DIRECTORY ${el})
       if(licfile)# if already set, unset and break; too many results
-        set(licfile )
-        break()
+        message(FATAL_ERROR "Could not find license unambiguously. Found:\n  ${licfile}\n ${el}")
       else()# set licfile to the one found
         set(licfile ${el})
       endif()


### PR DESCRIPTION
Enable this for Boost.
[PACKAGE]_LICENSE holds location of installed license.

Only enabled for ```url_sha1_boost``` scheme. Can be enabled for others later.

Partially solves #162 for Boost