### PR TITLE
Fix OpenSSL builds with MSVC.

### DIFF
--- a/cmake/schemes/url_sha1_openssl_windows.cmake.in
+++ b/cmake/schemes/url_sha1_openssl_windows.cmake.in
@@ -64,6 +64,14 @@ else()
   set(do_ms do_ms.bat)
 endif()
 
+if("@MSVC@")
+  # Logging as Workaround for VS_UNICODE_OUTPUT issue:
+  # https://public.kitware.com/Bug/view.php?id=14266
+  set(log_opts LOG_CONFIGURE 1)
+else()
+  set(log_opts "")
+endif()
+
 ExternalProject_Add(
     "@HUNTER_EP_NAME@"
     URL
@@ -82,7 +90,7 @@ ExternalProject_Add(
     COMMAND
     perl Configure "${opt}" no-asm "--prefix=@HUNTER_PACKAGE_INSTALL_PREFIX@"
     COMMAND
-    ms/${do_ms}
+    "ms\\${do_ms}"
     BUILD_COMMAND
     nmake -f "ms\\nt.mak"
     BUILD_IN_SOURCE
@@ -96,4 +104,5 @@ ExternalProject_Add(
     "-Ddstfile=@HUNTER_PACKAGE_LICENSE_FILE@"
     -P
     "@HUNTER_SELF@/scripts/try-copy-license.cmake"
+    ${log_opts}
 )


### PR DESCRIPTION
OpenSSL is doind clang-cl detection by calling `cl.exe` with certain
arguments that aren't valid for MS cl.exe.  I'm not sure when this
behaviour started.  Just as happens with Boost, the instance of msvc
that runs the ExternalProject defines VS_UNICODE_OUTPUT to redirect all
output to a pipe.  That means is sees these non-fatal errors that are
happening all the way down in the OpenSSL configure step, and thinks the
build has failed.

This change works around the problem in the same way as the Boost scheme
by setting LOG_CONFIGURE, which wraps the ExternalProject build in a
script that insulates it from msvc's environment variables.