### PR TITLE
ZMQPP library addition

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -111,9 +111,7 @@ hunter_config(sparsehash VERSION 2.0.2)
 hunter_config(spdlog VERSION 1.0.0-p0)
 hunter_config(szip VERSION 2.1.0-p1)
 hunter_config(wxWidgets VERSION 3.0.2)
-hunter_config(ZeroMQ VERSION 4.1.4-p2)
 hunter_config(ZMQPP VERSION 4.1.2)
-hunter_config(Protobuf VERSION 3.0.0-beta-2)
 
 if(MINGW)
   # 1.60.0 broken:

--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -111,6 +111,9 @@ hunter_config(sparsehash VERSION 2.0.2)
 hunter_config(spdlog VERSION 1.0.0-p0)
 hunter_config(szip VERSION 2.1.0-p1)
 hunter_config(wxWidgets VERSION 3.0.2)
+hunter_config(ZeroMQ VERSION 4.1.4-p2)
+hunter_config(ZMQPP VERSION 4.1.2)
+hunter_config(Protobuf VERSION 3.0.0-beta-2)
 
 if(MINGW)
   # 1.60.0 broken:

--- a/cmake/projects/ZMQPP/hunter.cmake
+++ b/cmake/projects/ZMQPP/hunter.cmake
@@ -5,6 +5,7 @@ else()
 endif()
 
 include(hunter_add_version)
+include(hunter_cacheable)
 include(hunter_download)
 include(hunter_pick_scheme)
 
@@ -20,5 +21,5 @@ hunter_add_version(
   )
 
 hunter_pick_scheme(DEFAULT url_sha1_cmake)
-
+hunter_cacheable(ZMQPP)
 hunter_download(PACKAGE_NAME ZMQPP)

--- a/cmake/projects/ZMQPP/hunter.cmake
+++ b/cmake/projects/ZMQPP/hunter.cmake
@@ -15,9 +15,9 @@ hunter_add_version(
   VERSION
   "4.1.2"
   URL
-  "https://github.com/hunter-packages/zmqpp/archive/4.1.2-hunter.tar.gz"
+  "https://github.com/hunter-packages/zmqpp/archive/4.1.2-hunter-p2.tar.gz"
   SHA1
-  f7fb7ffda0d34fcc61b562e73f3e548490076ea9
+  549d2d0078ed636d90ed0febe687a058bdd0d64d
   )
 
 hunter_pick_scheme(DEFAULT url_sha1_cmake)

--- a/cmake/projects/ZMQPP/hunter.cmake
+++ b/cmake/projects/ZMQPP/hunter.cmake
@@ -14,9 +14,9 @@ hunter_add_version(
   VERSION
   "4.1.2"
   URL
-  "/home/kobold/Developments/zmqpp.tar.gz"
+  "https://github.com/hunter-packages/zmqpp/archive/4.1.2-hunter.tar.gz"
   SHA1
-  4934c38a30a7f6eb54acc7f13c713bad5c838daf
+  f7fb7ffda0d34fcc61b562e73f3e548490076ea9
   )
 
 hunter_pick_scheme(DEFAULT url_sha1_cmake)

--- a/cmake/projects/ZMQPP/hunter.cmake
+++ b/cmake/projects/ZMQPP/hunter.cmake
@@ -1,0 +1,24 @@
+if(DEFINED HUNTER_CMAKE_PROJECTS_ZMQPP_HUNTER_CMAKE_)
+  return()
+else()
+  set(HUNTER_CMAKE_PROJECTS_ZMQPP_HUNTER_CMAKE_ 1)
+endif()
+
+include(hunter_add_version)
+include(hunter_download)
+include(hunter_pick_scheme)
+
+hunter_add_version(
+  PACKAGE_NAME
+  ZMQPP
+  VERSION
+  "4.1.2"
+  URL
+  "/home/kobold/Developments/zmqpp.tar.gz"
+  SHA1
+  4934c38a30a7f6eb54acc7f13c713bad5c838daf
+  )
+
+hunter_pick_scheme(DEFAULT url_sha1_cmake)
+
+hunter_download(PACKAGE_NAME ZMQPP)

--- a/examples/ZMQPP/CMakeLists.txt
+++ b/examples/ZMQPP/CMakeLists.txt
@@ -4,12 +4,11 @@ cmake_minimum_required(VERSION 3.2)
 # * https://github.com/hunter-packages/gate
 include("../common.cmake")
 
-project(download-ZeroMQ)
+project(download-ZMQPP)
 
-hunter_add_package(ZeroMQ)
 hunter_add_package(ZMQPP)
 
-find_package(ZMQPP)
+find_package(ZMQPP CONFIG REQUIRED)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 add_executable(version main.cpp)

--- a/examples/ZMQPP/CMakeLists.txt
+++ b/examples/ZMQPP/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.2)
+
+# Emulate HunterGate:
+# * https://github.com/hunter-packages/gate
+include("../common.cmake")
+
+project(download-ZeroMQ)
+
+hunter_add_package(ZeroMQ)
+hunter_add_package(ZMQPP)
+
+find_package(ZMQPP)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+add_executable(version main.cpp)
+target_link_libraries(version ZMQPP::zmqpp)

--- a/examples/ZMQPP/main.cpp
+++ b/examples/ZMQPP/main.cpp
@@ -1,0 +1,16 @@
+//  Report 0MQ version
+
+#include <zmqpp/zmqpp.hpp>
+#include <zmq.h>
+#include <iostream>
+
+int main (void)
+{
+    uint8_t zmqpp_mj, zmqpp_mn, zmqpp_rev;
+    uint8_t zmq_mj, zmq_mn, zmq_rev;
+    zmqpp::version(zmqpp_mj, zmqpp_mn, zmqpp_rev);
+    zmqpp::zmq_version (zmq_mj, zmq_mn, zmq_rev);
+    std::cout << "ZMQPP version: " << static_cast<int>(zmqpp_mj) << "." << static_cast<int>(zmqpp_mn) << "." << static_cast<int>(zmqpp_rev) << std::endl;
+    std::cout << "ZeroMQ version: " << static_cast<int>(zmq_mj) << "." << static_cast<int>(zmq_mn) << "." << static_cast<int>(zmq_rev) << std::endl;
+    return 0;
+}


### PR DESCRIPTION
This is a c++11 library, so it won't compile on not C++11 environments. It basis on ZeroMQ that currently doesn't compile on Windows. This is the first pull request of issue #338.