### PR TITLE
SQLite3 in Linux to link with pthread and dl

### DIFF
--- a/cmake/find/FindSQLite3.cmake
+++ b/cmake/find/FindSQLite3.cmake
@@ -47,6 +47,20 @@ if(NOT TARGET "SQLite3")
           "${SQLITE3_LIBRARY}"
         DIRECTORY CACHE
     )
+
+    if(UNIX AND NOT APPLE AND NOT ANDROID) # if Linux
+      string(REGEX MATCH "\\.a$" _ends_in_dot_a "${SQLITE3_LIBRARY}")
+      string(COMPARE NOTEQUAL "${_ends_in_dot_a}" "" _sqlite_is_static)
+      if(_sqlite_is_static)
+        # when static linking we need to add pthread and dl libraries
+        find_package(Threads REQUIRED)
+        list(APPEND _sqlite3_static_library_dependencies Threads::Threads ${CMAKE_DL_LIBS})
+        set_target_properties("SQLite3"
+            PROPERTIES
+              INTERFACE_LINK_LIBRARIES "${_sqlite3_static_library_dependencies}"
+        )
+      endif()
+    endif()
   elseif(SQLite3_FIND_REQUIRED)
     message(FATAL_ERROR "Could not find SQLite3")
   endif()


### PR DESCRIPTION
Fix for Linux tests when linking to SQLite3 statically, they fail with unresolved symbols from `pthread` and `dl` library, such as:

https://travis-ci.org/ingenue/hunter/jobs/114990295
https://travis-ci.org/ingenue/hunter/jobs/114990296
https://travis-ci.org/ingenue/hunter/jobs/114990297

I'm sure if this is considered a proper fix or just a work-around. It was the best I could come up with.