### PR TITLE
added version 20151201 to ippicv project

### DIFF
--- a/cmake/projects/ippicv/hunter.cmake
+++ b/cmake/projects/ippicv/hunter.cmake
@@ -16,6 +16,41 @@ if(APPLE)
       PACKAGE_NAME
       ippicv
       VERSION
+      "20151201"
+      URL
+      "https://raw.githubusercontent.com/Itseez/opencv_3rdparty/81a676001ca8075ada498583e4166079e5744668/ippicv/ippicv_macosx_20151201.tgz"
+      SHA1
+      d3f641c05708aaa2e0e91f2a10e34c80bc217cde
+  )
+elseif(UNIX)
+  hunter_add_version(
+      PACKAGE_NAME
+      ippicv
+      VERSION
+      "20151201"
+      URL
+      "https://raw.githubusercontent.com/Itseez/opencv_3rdparty/81a676001ca8075ada498583e4166079e5744668/ippicv/ippicv_linux_20151201.tgz"
+      SHA1
+      2252c08aa3107f8e4194263e668ccff8c6e3783a
+  )
+elseif(WIN32)
+  hunter_add_version(
+      PACKAGE_NAME
+      ippicv
+      VERSION
+      "20151201"
+      URL
+      "https://raw.githubusercontent.com/Itseez/opencv_3rdparty/81a676001ca8075ada498583e4166079e5744668/ippicv/ippicv_windows_20151201.zip"
+      SHA1
+      3e596c7d798028699ae0ea870902288088a51a6d
+  )
+endif()
+
+if(APPLE)
+  hunter_add_version(
+      PACKAGE_NAME
+      ippicv
+      VERSION
       "20141027"
       URL
       "http://sourceforge.net/projects/opencvlibrary/files/3rdparty/ippicv/ippicv_macosx_20141027.tgz"


### PR DESCRIPTION
cmake/configs/default.cmake was not updated because it needs to be updated simultaneously with OpenCV 3.1.0, or else it breaks the current OpenCV 3.0.0's build