### PR TITLE
odb-compiler documentaiton for profile

### DIFF
--- a/cmake/find/Findodb-compiler.cmake
+++ b/cmake/find/Findodb-compiler.cmake
@@ -51,6 +51,8 @@
 #         prefix
 #       STANDARD                  # --std
 #         c++11
+#       PROFILE                   # --profile
+#         boost
 #       SLOC_LIMIT                # --sloc-limit
 #         99999
 #       ODB_PROLOGUE              # --odb-prologue


### PR DESCRIPTION
Minor documentation about `PROFILE` in odb-compiler to enable the boost profile.

Forgot this in a local git stash.