### PR TITLE
Adding OpenSSL dependency to Boost::boost

### DIFF
--- a/cmake/find/FindOpenSSL.cmake
+++ b/cmake/find/FindOpenSSL.cmake
@@ -54,6 +54,10 @@
 # (To distribute this file outside of CMake, substitute the full
 #  License text for the above reference.)
 
+if(HUNTER_STATUS_DEBUG)
+  message("[hunter] Custom FindOpenSSL module")
+endif()
+
 if (UNIX)
   find_package(PkgConfig QUIET)
   pkg_check_modules(_OPENSSL QUIET openssl)
@@ -102,9 +106,8 @@ set(_OPENSSL_ROOT_HINTS_AND_PATHS
 find_path(OPENSSL_INCLUDE_DIR
   NAMES
     openssl/ssl.h
-  ${_OPENSSL_ROOT_HINTS_AND_PATHS}
   HINTS
-    ${_OPENSSL_INCLUDEDIR}
+    "${OPENSSL_ROOT}"
   PATH_SUFFIXES
     include
 )

--- a/cmake/find/FindOpenSSL.cmake
+++ b/cmake/find/FindOpenSSL.cmake
@@ -1,19 +1,48 @@
-# - Try to find the OpenSSL encryption library
-# Once done this will define
+#.rst:
+# FindOpenSSL
+# -----------
 #
-#  OPENSSL_ROOT_DIR - Set this variable to the root installation of OpenSSL
+# Find the OpenSSL encryption library.
 #
-# Read-Only variables:
-#  OPENSSL_FOUND - system has the OpenSSL library
-#  OPENSSL_INCLUDE_DIR - the OpenSSL include directory
-#  OPENSSL_LIBRARIES - The libraries needed to use OpenSSL
-#  OPENSSL_VERSION - This is set to $major.$minor.$revision$path (eg. 0.9.8s)
+# Imported Targets
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the following :prop_tgt:`IMPORTED` targets:
+#
+# ``OpenSSL::SSL``
+#   The OpenSSL ``ssl`` library, if found.
+# ``OpenSSL::Crypto``
+#   The OpenSSL ``crypto`` library, if found.
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module will set the following variables in your project:
+#
+# ``OPENSSL_FOUND``
+#   System has the OpenSSL library.
+# ``OPENSSL_INCLUDE_DIR``
+#   The OpenSSL include directory.
+# ``OPENSSL_CRYPTO_LIBRARY``
+#   The OpenSSL crypto library.
+# ``OPENSSL_SSL_LIBRARY``
+#   The OpenSSL SSL library.
+# ``OPENSSL_LIBRARIES``
+#   All OpenSSL libraries.
+# ``OPENSSL_VERSION``
+#   This is set to ``$major.$minor.$revision$patch`` (e.g. ``0.9.8s``).
+#
+# Hints
+# ^^^^^
+#
+# Set ``OPENSSL_ROOT_DIR`` to the root directory of an OpenSSL installation.
+# Set ``OPENSSL_USE_STATIC_LIBS`` to ``TRUE`` to look for static libraries.
+# Set ``OPENSSL_MSVC_STATIC_RT`` set ``TRUE`` to choose the MT version of the lib.
 
 #=============================================================================
 # Copyright 2006-2009 Kitware, Inc.
 # Copyright 2006 Alexander Neundorf <neundorf@kde.org>
 # Copyright 2009-2011 Mathieu Malaterre <mathieu.malaterre@gmail.com>
-# Copyright 2015 Alexander Lamaison <alexander.lamaison@gmail.com>
 #
 # Distributed under the OSI-approved BSD License (the "License");
 # see accompanying file Copyright.txt for details.
@@ -25,15 +54,57 @@
 # (To distribute this file outside of CMake, substitute the full
 #  License text for the above reference.)
 
-if(HUNTER_STATUS_DEBUG)
-  message("[hunter] Custom FindOpenSSL module")
+if (UNIX)
+  find_package(PkgConfig QUIET)
+  pkg_check_modules(_OPENSSL QUIET openssl)
+endif ()
+
+# Support preference of static libs by adjusting CMAKE_FIND_LIBRARY_SUFFIXES
+if(OPENSSL_USE_STATIC_LIBS)
+  set(_openssl_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  if(WIN32)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .lib .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  else()
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a )
+  endif()
 endif()
+
+if (WIN32)
+  # http://www.slproweb.com/products/Win32OpenSSL.html
+  set(_OPENSSL_ROOT_HINTS
+    ${OPENSSL_ROOT_DIR}
+    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL (32-bit)_is1;Inno Setup: App Path]"
+    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL (64-bit)_is1;Inno Setup: App Path]"
+    ENV OPENSSL_ROOT_DIR
+    )
+  file(TO_CMAKE_PATH "$ENV{PROGRAMFILES}" _programfiles)
+  set(_OPENSSL_ROOT_PATHS
+    "${_programfiles}/OpenSSL"
+    "${_programfiles}/OpenSSL-Win32"
+    "${_programfiles}/OpenSSL-Win64"
+    "C:/OpenSSL/"
+    "C:/OpenSSL-Win32/"
+    "C:/OpenSSL-Win64/"
+    )
+  unset(_programfiles)
+else ()
+  set(_OPENSSL_ROOT_HINTS
+    ${OPENSSL_ROOT_DIR}
+    ENV OPENSSL_ROOT_DIR
+    )
+endif ()
+
+set(_OPENSSL_ROOT_HINTS_AND_PATHS
+    HINTS ${_OPENSSL_ROOT_HINTS}
+    PATHS ${_OPENSSL_ROOT_PATHS}
+    )
 
 find_path(OPENSSL_INCLUDE_DIR
   NAMES
     openssl/ssl.h
+  ${_OPENSSL_ROOT_HINTS_AND_PATHS}
   HINTS
-    "${OPENSSL_ROOT}"
+    ${_OPENSSL_INCLUDEDIR}
   PATH_SUFFIXES
     include
 )
@@ -43,7 +114,7 @@ if(WIN32 AND NOT CYGWIN)
     # /MD and /MDd are the standard values - if someone wants to use
     # others, the libnames have to change here too
     # use also ssl and ssleay32 in debug as fallback for openssl < 0.9.8b
-    # TODO: handle /MT and static lib
+    # enable OPENSSL_MSVC_STATIC_RT to get the libs build /MT (Multithreaded no-DLL)
     # In Visual C++ naming convention each of these four kinds of Windows libraries has it's standard suffix:
     #   * MD for dynamic-release
     #   * MDd for dynamic-debug
@@ -54,53 +125,63 @@ if(WIN32 AND NOT CYGWIN)
     # We are using the libraries located in the VC subdir instead of the parent directory eventhough :
     # libeay32MD.lib is identical to ../libeay32.lib, and
     # ssleay32MD.lib is identical to ../ssleay32.lib
-    find_library(LIB_EAY_DEBUG
-      NAMES
-        libeay32MDd
-        libeay32d
-      HINTS
-        "${OPENSSL_ROOT}"
-      PATH_SUFFIXES
+    # enable OPENSSL_USE_STATIC_LIBS to use the static libs located in lib/VC/static
+
+    if (OPENSSL_MSVC_STATIC_RT)
+      set(_OPENSSL_MSVC_RT_MODE "MT")
+    else ()
+      set(_OPENSSL_MSVC_RT_MODE "MD")
+    endif ()
+
+    if(OPENSSL_USE_STATIC_LIBS)
+      set(_OPENSSL_PATH_SUFFIXES
+        "lib"
+        "VC/static"
+        "lib/VC/static"
+        )
+    else()
+      set(_OPENSSL_PATH_SUFFIXES
         "lib"
         "VC"
         "lib/VC"
+        )
+    endif ()
+
+    find_library(LIB_EAY_DEBUG
+      NAMES
+        libeay32${_OPENSSL_MSVC_RT_MODE}d
+        libeay32d
+      ${_OPENSSL_ROOT_HINTS_AND_PATHS}
+      PATH_SUFFIXES
+        ${_OPENSSL_PATH_SUFFIXES}
     )
 
     find_library(LIB_EAY_RELEASE
       NAMES
-        libeay32MD
+        libeay32${_OPENSSL_MSVC_RT_MODE}
         libeay32
-      HINTS
-        "${OPENSSL_ROOT}"
+      ${_OPENSSL_ROOT_HINTS_AND_PATHS}
       PATH_SUFFIXES
-        "lib"
-        "VC"
-        "lib/VC"
+        ${_OPENSSL_PATH_SUFFIXES}
     )
 
     find_library(SSL_EAY_DEBUG
       NAMES
-        ssleay32MDd
+        ssleay32${_OPENSSL_MSVC_RT_MODE}d
         ssleay32d
-      HINTS
-        "${OPENSSL_ROOT}"
+      ${_OPENSSL_ROOT_HINTS_AND_PATHS}
       PATH_SUFFIXES
-        "lib"
-        "VC"
-        "lib/VC"
+        ${_OPENSSL_PATH_SUFFIXES}
     )
 
     find_library(SSL_EAY_RELEASE
       NAMES
-        ssleay32MD
+        ssleay32${_OPENSSL_MSVC_RT_MODE}
         ssleay32
         ssl
-      HINTS
-        "${OPENSSL_ROOT}"
+      ${_OPENSSL_ROOT_HINTS_AND_PATHS}
       PATH_SUFFIXES
-        "lib"
-        "VC"
-        "lib/VC"
+        ${_OPENSSL_PATH_SUFFIXES}
     )
 
     set(LIB_EAY_LIBRARY_DEBUG "${LIB_EAY_DEBUG}")
@@ -112,20 +193,19 @@ if(WIN32 AND NOT CYGWIN)
     select_library_configurations(LIB_EAY)
     select_library_configurations(SSL_EAY)
 
-    set( OPENSSL_LIBRARIES ${SSL_EAY_LIBRARY} ${LIB_EAY_LIBRARY} )
+    mark_as_advanced(LIB_EAY_LIBRARY_DEBUG LIB_EAY_LIBRARY_RELEASE
+                     SSL_EAY_LIBRARY_DEBUG SSL_EAY_LIBRARY_RELEASE)
+    set(OPENSSL_SSL_LIBRARY ${SSL_EAY_LIBRARY} )
+    set(OPENSSL_CRYPTO_LIBRARY ${LIB_EAY_LIBRARY} )
+    set(OPENSSL_LIBRARIES ${SSL_EAY_LIBRARY} ${LIB_EAY_LIBRARY} )
   elseif(MINGW)
     # same player, for MinGW
-    set(LIB_EAY_NAMES libeay32)
-    set(SSL_EAY_NAMES ssleay32)
-    if(CMAKE_CROSSCOMPILING)
-      list(APPEND LIB_EAY_NAMES crypto)
-      list(APPEND SSL_EAY_NAMES ssl)
-    endif()
+    set(LIB_EAY_NAMES crypto libeay32)
+    set(SSL_EAY_NAMES ssl ssleay32)
     find_library(LIB_EAY
       NAMES
         ${LIB_EAY_NAMES}
-      HINTS
-        "${OPENSSL_ROOT}"
+      ${_OPENSSL_ROOT_HINTS_AND_PATHS}
       PATH_SUFFIXES
         "lib"
         "lib/MinGW"
@@ -134,15 +214,16 @@ if(WIN32 AND NOT CYGWIN)
     find_library(SSL_EAY
       NAMES
         ${SSL_EAY_NAMES}
-      HINTS
-        "${OPENSSL_ROOT}"
+      ${_OPENSSL_ROOT_HINTS_AND_PATHS}
       PATH_SUFFIXES
         "lib"
         "lib/MinGW"
     )
 
     mark_as_advanced(SSL_EAY LIB_EAY)
-    set( OPENSSL_LIBRARIES ${SSL_EAY} ${LIB_EAY} )
+    set(OPENSSL_SSL_LIBRARY ${SSL_EAY} )
+    set(OPENSSL_CRYPTO_LIBRARY ${LIB_EAY} )
+    set(OPENSSL_LIBRARIES ${SSL_EAY} ${LIB_EAY} )
     unset(LIB_EAY_NAMES)
     unset(SSL_EAY_NAMES)
   else()
@@ -150,8 +231,9 @@ if(WIN32 AND NOT CYGWIN)
     find_library(LIB_EAY
       NAMES
         libeay32
+      ${_OPENSSL_ROOT_HINTS_AND_PATHS}
       HINTS
-        "${OPENSSL_ROOT}"
+        ${_OPENSSL_LIBDIR}
       PATH_SUFFIXES
         lib
     )
@@ -159,14 +241,17 @@ if(WIN32 AND NOT CYGWIN)
     find_library(SSL_EAY
       NAMES
         ssleay32
+      ${_OPENSSL_ROOT_HINTS_AND_PATHS}
       HINTS
-        "${OPENSSL_ROOT}"
+        ${_OPENSSL_LIBDIR}
       PATH_SUFFIXES
         lib
     )
 
     mark_as_advanced(SSL_EAY LIB_EAY)
-    set( OPENSSL_LIBRARIES ${SSL_EAY} ${LIB_EAY} )
+    set(OPENSSL_SSL_LIBRARY ${SSL_EAY} )
+    set(OPENSSL_CRYPTO_LIBRARY ${LIB_EAY} )
+    set(OPENSSL_LIBRARIES ${SSL_EAY} ${LIB_EAY} )
   endif()
 else()
 
@@ -175,8 +260,9 @@ else()
       ssl
       ssleay32
       ssleay32MD
+    ${_OPENSSL_ROOT_HINTS_AND_PATHS}
     HINTS
-      "${OPENSSL_ROOT}"
+      ${_OPENSSL_LIBDIR}
     PATH_SUFFIXES
       lib
   )
@@ -184,8 +270,9 @@ else()
   find_library(OPENSSL_CRYPTO_LIBRARY
     NAMES
       crypto
+    ${_OPENSSL_ROOT_HINTS_AND_PATHS}
     HINTS
-      "${OPENSSL_ROOT}"
+      ${_OPENSSL_LIBDIR}
     PATH_SUFFIXES
       lib
   )
@@ -196,7 +283,7 @@ else()
   set(OPENSSL_SSL_LIBRARIES ${OPENSSL_SSL_LIBRARY})
   set(OPENSSL_CRYPTO_LIBRARIES ${OPENSSL_CRYPTO_LIBRARY})
 
-  set(OPENSSL_LIBRARIES ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY} ${CMAKE_DL_LIBS})
+  set(OPENSSL_LIBRARIES ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
 
 endif()
 
@@ -231,47 +318,40 @@ function(from_hex HEX DEC)
   set(${DEC} ${_res} PARENT_SCOPE)
 endfunction()
 
-if(OPENSSL_INCLUDE_DIR AND EXISTS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h")
-  file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" openssl_version_str
-    REGEX "^#[\t ]*define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])+.*")
+if (OPENSSL_INCLUDE_DIR)
+  if(OPENSSL_INCLUDE_DIR AND EXISTS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h")
+    file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" openssl_version_str
+         REGEX "^#[\t ]*define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])+.*")
 
-  string(COMPARE EQUAL "${openssl_version_str}" "" _is_empty)
-  if(_is_empty)
-    message(
-        FATAL_ERROR
-        "Incorrect OPENSSL_VERSION_NUMBER define in header"
-        ": ${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h"
-    )
-  endif()
+    # The version number is encoded as 0xMNNFFPPS: major minor fix patch status
+    # The status gives if this is a developer or prerelease and is ignored here.
+    # Major, minor, and fix directly translate into the version numbers shown in
+    # the string. The patch field translates to the single character suffix that
+    # indicates the bug fix state, which 00 -> nothing, 01 -> a, 02 -> b and so
+    # on.
 
-  # The version number is encoded as 0xMNNFFPPS: major minor fix patch status
-  # The status gives if this is a developer or prerelease and is ignored here.
-  # Major, minor, and fix directly translate into the version numbers shown in
-  # the string. The patch field translates to the single character suffix that
-  # indicates the bug fix state, which 00 -> nothing, 01 -> a, 02 -> b and so
-  # on.
+    string(REGEX REPLACE "^.*OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])([0-9a-fA-F][0-9a-fA-F])([0-9a-fA-F][0-9a-fA-F])([0-9a-fA-F][0-9a-fA-F])([0-9a-fA-F]).*$"
+           "\\1;\\2;\\3;\\4;\\5" OPENSSL_VERSION_LIST "${openssl_version_str}")
+    list(GET OPENSSL_VERSION_LIST 0 OPENSSL_VERSION_MAJOR)
+    list(GET OPENSSL_VERSION_LIST 1 OPENSSL_VERSION_MINOR)
+    from_hex("${OPENSSL_VERSION_MINOR}" OPENSSL_VERSION_MINOR)
+    list(GET OPENSSL_VERSION_LIST 2 OPENSSL_VERSION_FIX)
+    from_hex("${OPENSSL_VERSION_FIX}" OPENSSL_VERSION_FIX)
+    list(GET OPENSSL_VERSION_LIST 3 OPENSSL_VERSION_PATCH)
 
-  string(REGEX REPLACE "^.*OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])([0-9a-fA-F][0-9a-fA-F])([0-9a-fA-F][0-9a-fA-F])([0-9a-fA-F][0-9a-fA-F])([0-9a-fA-F]).*$"
-    "\\1;\\2;\\3;\\4;\\5" OPENSSL_VERSION_LIST "${openssl_version_str}")
-  list(GET OPENSSL_VERSION_LIST 0 OPENSSL_VERSION_MAJOR)
-  list(GET OPENSSL_VERSION_LIST 1 OPENSSL_VERSION_MINOR)
-  from_hex("${OPENSSL_VERSION_MINOR}" OPENSSL_VERSION_MINOR)
-  list(GET OPENSSL_VERSION_LIST 2 OPENSSL_VERSION_FIX)
-  from_hex("${OPENSSL_VERSION_FIX}" OPENSSL_VERSION_FIX)
-  list(GET OPENSSL_VERSION_LIST 3 OPENSSL_VERSION_PATCH)
+    if (NOT OPENSSL_VERSION_PATCH STREQUAL "00")
+      from_hex("${OPENSSL_VERSION_PATCH}" _tmp)
+      # 96 is the ASCII code of 'a' minus 1
+      math(EXPR OPENSSL_VERSION_PATCH_ASCII "${_tmp} + 96")
+      unset(_tmp)
+      # Once anyone knows how OpenSSL would call the patch versions beyond 'z'
+      # this should be updated to handle that, too. This has not happened yet
+      # so it is simply ignored here for now.
+      string(ASCII "${OPENSSL_VERSION_PATCH_ASCII}" OPENSSL_VERSION_PATCH_STRING)
+    endif ()
 
-  if (NOT OPENSSL_VERSION_PATCH STREQUAL "00")
-    from_hex("${OPENSSL_VERSION_PATCH}" _tmp)
-    # 96 is the ASCII code of 'a' minus 1
-    math(EXPR OPENSSL_VERSION_PATCH_ASCII "${_tmp} + 96")
-    unset(_tmp)
-    # Once anyone knows how OpenSSL would call the patch versions beyond 'z'
-    # this should be updated to handle that, too. This has not happened yet
-    # so it is simply ignored here for now.
-    string(ASCII "${OPENSSL_VERSION_PATCH_ASCII}" OPENSSL_VERSION_PATCH_STRING)
+    set(OPENSSL_VERSION "${OPENSSL_VERSION_MAJOR}.${OPENSSL_VERSION_MINOR}.${OPENSSL_VERSION_FIX}${OPENSSL_VERSION_PATCH_STRING}")
   endif ()
-
-  set(OPENSSL_VERSION "${OPENSSL_VERSION_MAJOR}.${OPENSSL_VERSION_MINOR}.${OPENSSL_VERSION_FIX}${OPENSSL_VERSION_PATCH_STRING}")
 endif ()
 
 include(FindPackageHandleStandardArgs)
@@ -294,3 +374,71 @@ else ()
 endif ()
 
 mark_as_advanced(OPENSSL_INCLUDE_DIR OPENSSL_LIBRARIES)
+
+if(OPENSSL_FOUND)
+  if(NOT TARGET OpenSSL::Crypto AND
+      (EXISTS "${OPENSSL_CRYPTO_LIBRARY}" OR
+        EXISTS "${LIB_EAY_LIBRARY_DEBUG}" OR
+        EXISTS "${LIB_EAY_LIBRARY_RELEASE}")
+      )
+    add_library(OpenSSL::Crypto UNKNOWN IMPORTED)
+    set_target_properties(OpenSSL::Crypto PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${OPENSSL_INCLUDE_DIR}")
+    if(EXISTS "${OPENSSL_CRYPTO_LIBRARY}")
+      set_target_properties(OpenSSL::Crypto PROPERTIES
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+        IMPORTED_LOCATION "${OPENSSL_CRYPTO_LIBRARY}")
+    endif()
+    if(EXISTS "${LIB_EAY_LIBRARY_DEBUG}")
+      set_property(TARGET OpenSSL::Crypto APPEND PROPERTY
+        IMPORTED_CONFIGURATIONS DEBUG)
+      set_target_properties(OpenSSL::Crypto PROPERTIES
+        IMPORTED_LINK_INTERFACE_LANGUAGES_DEBUG "C"
+        IMPORTED_LOCATION_DEBUG "${LIB_EAY_LIBRARY_DEBUG}")
+    endif()
+    if(EXISTS "${LIB_EAY_LIBRARY_RELEASE}")
+      set_property(TARGET OpenSSL::Crypto APPEND PROPERTY
+        IMPORTED_CONFIGURATIONS RELEASE)
+      set_target_properties(OpenSSL::Crypto PROPERTIES
+        IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "C"
+        IMPORTED_LOCATION_RELEASE "${LIB_EAY_LIBRARY_RELEASE}")
+    endif()
+  endif()
+  if(NOT TARGET OpenSSL::SSL AND
+      (EXISTS "${OPENSSL_SSL_LIBRARY}" OR
+        EXISTS "${SSL_EAY_LIBRARY_DEBUG}" OR
+        EXISTS "${SSL_EAY_LIBRARY_RELEASE}")
+      )
+    add_library(OpenSSL::SSL UNKNOWN IMPORTED)
+    set_target_properties(OpenSSL::SSL PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${OPENSSL_INCLUDE_DIR}")
+    if(EXISTS "${OPENSSL_SSL_LIBRARY}")
+      set_target_properties(OpenSSL::SSL PROPERTIES
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+        IMPORTED_LOCATION "${OPENSSL_SSL_LIBRARY}")
+    endif()
+    if(EXISTS "${SSL_EAY_LIBRARY_DEBUG}")
+      set_property(TARGET OpenSSL::SSL APPEND PROPERTY
+        IMPORTED_CONFIGURATIONS DEBUG)
+      set_target_properties(OpenSSL::SSL PROPERTIES
+        IMPORTED_LINK_INTERFACE_LANGUAGES_DEBUG "C"
+        IMPORTED_LOCATION_DEBUG "${SSL_EAY_LIBRARY_DEBUG}")
+    endif()
+    if(EXISTS "${SSL_EAY_LIBRARY_RELEASE}")
+      set_property(TARGET OpenSSL::SSL APPEND PROPERTY
+        IMPORTED_CONFIGURATIONS RELEASE)
+      set_target_properties(OpenSSL::SSL PROPERTIES
+        IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "C"
+        IMPORTED_LOCATION_RELEASE "${SSL_EAY_LIBRARY_RELEASE}")
+    endif()
+    if(TARGET OpenSSL::Crypto)
+      set_target_properties(OpenSSL::SSL PROPERTIES
+        INTERFACE_LINK_LIBRARIES OpenSSL::Crypto)
+    endif()
+  endif()
+endif()
+
+# Restore the original find library ordering
+if(OPENSSL_USE_STATIC_LIBS)
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${_openssl_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+endif()

--- a/cmake/find/FindOpenSSL.cmake
+++ b/cmake/find/FindOpenSSL.cmake
@@ -43,6 +43,7 @@
 # Copyright 2006-2009 Kitware, Inc.
 # Copyright 2006 Alexander Neundorf <neundorf@kde.org>
 # Copyright 2009-2011 Mathieu Malaterre <mathieu.malaterre@gmail.com>
+# Copyright 2015 Alexander Lamaison <alexander.lamaison@gmail.com>
 #
 # Distributed under the OSI-approved BSD License (the "License");
 # see accompanying file Copyright.txt for details.
@@ -58,11 +59,6 @@ if(HUNTER_STATUS_DEBUG)
   message("[hunter] Custom FindOpenSSL module")
 endif()
 
-if (UNIX)
-  find_package(PkgConfig QUIET)
-  pkg_check_modules(_OPENSSL QUIET openssl)
-endif ()
-
 # Support preference of static libs by adjusting CMAKE_FIND_LIBRARY_SUFFIXES
 if(OPENSSL_USE_STATIC_LIBS)
   set(_openssl_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
@@ -72,36 +68,6 @@ if(OPENSSL_USE_STATIC_LIBS)
     set(CMAKE_FIND_LIBRARY_SUFFIXES .a )
   endif()
 endif()
-
-if (WIN32)
-  # http://www.slproweb.com/products/Win32OpenSSL.html
-  set(_OPENSSL_ROOT_HINTS
-    ${OPENSSL_ROOT_DIR}
-    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL (32-bit)_is1;Inno Setup: App Path]"
-    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL (64-bit)_is1;Inno Setup: App Path]"
-    ENV OPENSSL_ROOT_DIR
-    )
-  file(TO_CMAKE_PATH "$ENV{PROGRAMFILES}" _programfiles)
-  set(_OPENSSL_ROOT_PATHS
-    "${_programfiles}/OpenSSL"
-    "${_programfiles}/OpenSSL-Win32"
-    "${_programfiles}/OpenSSL-Win64"
-    "C:/OpenSSL/"
-    "C:/OpenSSL-Win32/"
-    "C:/OpenSSL-Win64/"
-    )
-  unset(_programfiles)
-else ()
-  set(_OPENSSL_ROOT_HINTS
-    ${OPENSSL_ROOT_DIR}
-    ENV OPENSSL_ROOT_DIR
-    )
-endif ()
-
-set(_OPENSSL_ROOT_HINTS_AND_PATHS
-    HINTS ${_OPENSSL_ROOT_HINTS}
-    PATHS ${_OPENSSL_ROOT_PATHS}
-    )
 
 find_path(OPENSSL_INCLUDE_DIR
   NAMES
@@ -154,7 +120,8 @@ if(WIN32 AND NOT CYGWIN)
       NAMES
         libeay32${_OPENSSL_MSVC_RT_MODE}d
         libeay32d
-      ${_OPENSSL_ROOT_HINTS_AND_PATHS}
+      HINTS
+        "${OPENSSL_ROOT}"
       PATH_SUFFIXES
         ${_OPENSSL_PATH_SUFFIXES}
     )
@@ -163,7 +130,8 @@ if(WIN32 AND NOT CYGWIN)
       NAMES
         libeay32${_OPENSSL_MSVC_RT_MODE}
         libeay32
-      ${_OPENSSL_ROOT_HINTS_AND_PATHS}
+      HINTS
+        "${OPENSSL_ROOT}"
       PATH_SUFFIXES
         ${_OPENSSL_PATH_SUFFIXES}
     )
@@ -172,7 +140,8 @@ if(WIN32 AND NOT CYGWIN)
       NAMES
         ssleay32${_OPENSSL_MSVC_RT_MODE}d
         ssleay32d
-      ${_OPENSSL_ROOT_HINTS_AND_PATHS}
+      HINTS
+        "${OPENSSL_ROOT}"
       PATH_SUFFIXES
         ${_OPENSSL_PATH_SUFFIXES}
     )
@@ -182,7 +151,8 @@ if(WIN32 AND NOT CYGWIN)
         ssleay32${_OPENSSL_MSVC_RT_MODE}
         ssleay32
         ssl
-      ${_OPENSSL_ROOT_HINTS_AND_PATHS}
+      HINTS
+        "${OPENSSL_ROOT}"
       PATH_SUFFIXES
         ${_OPENSSL_PATH_SUFFIXES}
     )
@@ -208,7 +178,8 @@ if(WIN32 AND NOT CYGWIN)
     find_library(LIB_EAY
       NAMES
         ${LIB_EAY_NAMES}
-      ${_OPENSSL_ROOT_HINTS_AND_PATHS}
+      HINTS
+        "${OPENSSL_ROOT}"
       PATH_SUFFIXES
         "lib"
         "lib/MinGW"
@@ -217,7 +188,8 @@ if(WIN32 AND NOT CYGWIN)
     find_library(SSL_EAY
       NAMES
         ${SSL_EAY_NAMES}
-      ${_OPENSSL_ROOT_HINTS_AND_PATHS}
+      HINTS
+        "${OPENSSL_ROOT}"
       PATH_SUFFIXES
         "lib"
         "lib/MinGW"
@@ -234,9 +206,8 @@ if(WIN32 AND NOT CYGWIN)
     find_library(LIB_EAY
       NAMES
         libeay32
-      ${_OPENSSL_ROOT_HINTS_AND_PATHS}
       HINTS
-        ${_OPENSSL_LIBDIR}
+        "${OPENSSL_ROOT}"
       PATH_SUFFIXES
         lib
     )
@@ -244,9 +215,8 @@ if(WIN32 AND NOT CYGWIN)
     find_library(SSL_EAY
       NAMES
         ssleay32
-      ${_OPENSSL_ROOT_HINTS_AND_PATHS}
       HINTS
-        ${_OPENSSL_LIBDIR}
+        "${OPENSSL_ROOT}"
       PATH_SUFFIXES
         lib
     )
@@ -263,9 +233,8 @@ else()
       ssl
       ssleay32
       ssleay32MD
-    ${_OPENSSL_ROOT_HINTS_AND_PATHS}
     HINTS
-      ${_OPENSSL_LIBDIR}
+      "${OPENSSL_ROOT}"
     PATH_SUFFIXES
       lib
   )
@@ -273,9 +242,8 @@ else()
   find_library(OPENSSL_CRYPTO_LIBRARY
     NAMES
       crypto
-    ${_OPENSSL_ROOT_HINTS_AND_PATHS}
     HINTS
-      ${_OPENSSL_LIBDIR}
+      "${OPENSSL_ROOT}"
     PATH_SUFFIXES
       lib
   )
@@ -321,40 +289,47 @@ function(from_hex HEX DEC)
   set(${DEC} ${_res} PARENT_SCOPE)
 endfunction()
 
-if (OPENSSL_INCLUDE_DIR)
-  if(OPENSSL_INCLUDE_DIR AND EXISTS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h")
-    file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" openssl_version_str
-         REGEX "^#[\t ]*define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])+.*")
+if(OPENSSL_INCLUDE_DIR AND EXISTS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h")
+  file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" openssl_version_str
+    REGEX "^#[\t ]*define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])+.*")
 
-    # The version number is encoded as 0xMNNFFPPS: major minor fix patch status
-    # The status gives if this is a developer or prerelease and is ignored here.
-    # Major, minor, and fix directly translate into the version numbers shown in
-    # the string. The patch field translates to the single character suffix that
-    # indicates the bug fix state, which 00 -> nothing, 01 -> a, 02 -> b and so
-    # on.
+  string(COMPARE EQUAL "${openssl_version_str}" "" _is_empty)
+  if(_is_empty)
+    message(
+        FATAL_ERROR
+        "Incorrect OPENSSL_VERSION_NUMBER define in header"
+        ": ${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h"
+    )
+  endif()
 
-    string(REGEX REPLACE "^.*OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])([0-9a-fA-F][0-9a-fA-F])([0-9a-fA-F][0-9a-fA-F])([0-9a-fA-F][0-9a-fA-F])([0-9a-fA-F]).*$"
-           "\\1;\\2;\\3;\\4;\\5" OPENSSL_VERSION_LIST "${openssl_version_str}")
-    list(GET OPENSSL_VERSION_LIST 0 OPENSSL_VERSION_MAJOR)
-    list(GET OPENSSL_VERSION_LIST 1 OPENSSL_VERSION_MINOR)
-    from_hex("${OPENSSL_VERSION_MINOR}" OPENSSL_VERSION_MINOR)
-    list(GET OPENSSL_VERSION_LIST 2 OPENSSL_VERSION_FIX)
-    from_hex("${OPENSSL_VERSION_FIX}" OPENSSL_VERSION_FIX)
-    list(GET OPENSSL_VERSION_LIST 3 OPENSSL_VERSION_PATCH)
+  # The version number is encoded as 0xMNNFFPPS: major minor fix patch status
+  # The status gives if this is a developer or prerelease and is ignored here.
+  # Major, minor, and fix directly translate into the version numbers shown in
+  # the string. The patch field translates to the single character suffix that
+  # indicates the bug fix state, which 00 -> nothing, 01 -> a, 02 -> b and so
+  # on.
 
-    if (NOT OPENSSL_VERSION_PATCH STREQUAL "00")
-      from_hex("${OPENSSL_VERSION_PATCH}" _tmp)
-      # 96 is the ASCII code of 'a' minus 1
-      math(EXPR OPENSSL_VERSION_PATCH_ASCII "${_tmp} + 96")
-      unset(_tmp)
-      # Once anyone knows how OpenSSL would call the patch versions beyond 'z'
-      # this should be updated to handle that, too. This has not happened yet
-      # so it is simply ignored here for now.
-      string(ASCII "${OPENSSL_VERSION_PATCH_ASCII}" OPENSSL_VERSION_PATCH_STRING)
-    endif ()
+  string(REGEX REPLACE "^.*OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])([0-9a-fA-F][0-9a-fA-F])([0-9a-fA-F][0-9a-fA-F])([0-9a-fA-F][0-9a-fA-F])([0-9a-fA-F]).*$"
+    "\\1;\\2;\\3;\\4;\\5" OPENSSL_VERSION_LIST "${openssl_version_str}")
+  list(GET OPENSSL_VERSION_LIST 0 OPENSSL_VERSION_MAJOR)
+  list(GET OPENSSL_VERSION_LIST 1 OPENSSL_VERSION_MINOR)
+  from_hex("${OPENSSL_VERSION_MINOR}" OPENSSL_VERSION_MINOR)
+  list(GET OPENSSL_VERSION_LIST 2 OPENSSL_VERSION_FIX)
+  from_hex("${OPENSSL_VERSION_FIX}" OPENSSL_VERSION_FIX)
+  list(GET OPENSSL_VERSION_LIST 3 OPENSSL_VERSION_PATCH)
 
-    set(OPENSSL_VERSION "${OPENSSL_VERSION_MAJOR}.${OPENSSL_VERSION_MINOR}.${OPENSSL_VERSION_FIX}${OPENSSL_VERSION_PATCH_STRING}")
+  if (NOT OPENSSL_VERSION_PATCH STREQUAL "00")
+    from_hex("${OPENSSL_VERSION_PATCH}" _tmp)
+    # 96 is the ASCII code of 'a' minus 1
+    math(EXPR OPENSSL_VERSION_PATCH_ASCII "${_tmp} + 96")
+    unset(_tmp)
+    # Once anyone knows how OpenSSL would call the patch versions beyond 'z'
+    # this should be updated to handle that, too. This has not happened yet
+    # so it is simply ignored here for now.
+    string(ASCII "${OPENSSL_VERSION_PATCH_ASCII}" OPENSSL_VERSION_PATCH_STRING)
   endif ()
+
+  set(OPENSSL_VERSION "${OPENSSL_VERSION_MAJOR}.${OPENSSL_VERSION_MINOR}.${OPENSSL_VERSION_FIX}${OPENSSL_VERSION_PATCH_STRING}")
 endif ()
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/templates/BoostConfig.cmake.in
+++ b/cmake/templates/BoostConfig.cmake.in
@@ -39,18 +39,6 @@ if(NOT TARGET "Boost::boost")
         INTERFACE_COMPILE_DEFINITIONS "BOOST_ALL_NO_LIB=1"
     )
   endif()
-
-  if(BOOST_CONFIG_LINK_OPENSSL)
-    hunter_add_package(OpenSSL)
-
-    find_package(OpenSSL REQUIRED)
-    set_target_properties(
-      "Boost::boost"
-      PROPERTIES
-      INTERFACE_LINK_LIBRARIES "${OPENSSL_LIBRARIES}"
-      )
-
-  endif()
 endif()
 
 foreach(_boost_component ${Boost_FIND_COMPONENTS})

--- a/cmake/templates/BoostConfig.cmake.in
+++ b/cmake/templates/BoostConfig.cmake.in
@@ -39,6 +39,18 @@ if(NOT TARGET "Boost::boost")
         INTERFACE_COMPILE_DEFINITIONS "BOOST_ALL_NO_LIB=1"
     )
   endif()
+
+  if(BOOST_CONFIG_LINK_OPENSSL)
+    hunter_add_package(OpenSSL)
+
+    find_package(OpenSSL REQUIRED)
+    set_target_properties(
+      "Boost::boost"
+      PROPERTIES
+      INTERFACE_LINK_LIBRARIES "${OPENSSL_LIBRARIES}"
+      )
+
+  endif()
 endif()
 
 foreach(_boost_component ${Boost_FIND_COMPONENTS})

--- a/examples/OpenSSL-imported/CMakeLists.txt
+++ b/examples/OpenSSL-imported/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) 2014, Ruslan Baratov
+# All rights reserved.
+
+cmake_minimum_required(VERSION 3.0)
+
+# Emulate HunterGate:
+# * https://github.com/hunter-packages/gate
+include("../common.cmake")
+
+project(download-openssl)
+
+# download gtest
+hunter_add_package(OpenSSL)
+
+# now gtest can be used
+find_package(OpenSSL REQUIRED)
+
+add_executable(foo foo.cpp)
+target_link_libraries(foo OpenSSL::SSL OpenSSL::Crypto)

--- a/examples/OpenSSL-imported/foo.cpp
+++ b/examples/OpenSSL-imported/foo.cpp
@@ -1,0 +1,4 @@
+#include <openssl/crypto.h>
+
+int main() {
+}


### PR DESCRIPTION
websocketpp required OpenSSL for Boost::asio (that is a header only library). Now Boost::boost can be linked together with OpenSSL libraries depending on BOOST_CONFIG_LINK_OPENSSL variable.