### PR TITLE
Add fmt (cppformat) 3.0.0

### DIFF
--- a/cmake/projects/fmt/hunter.cmake
+++ b/cmake/projects/fmt/hunter.cmake
@@ -1,0 +1,32 @@
+# !!! DO NOT PLACE HEADER GUARDS HERE !!!
+
+# Load used modules
+include(hunter_add_version)
+include(hunter_cmake_args)
+include(hunter_download)
+include(hunter_pick_scheme)
+
+# List of versions here...
+hunter_add_version(
+    PACKAGE_NAME
+    fmt
+    VERSION
+    "3.0.0"
+    URL
+    "https://github.com/fmtlib/fmt/releases/download/3.0.0/fmt-3.0.0.zip"
+    SHA1
+    82ca4625f977ee1e0627ce8421bc52fbbf6e5cc5
+)
+
+hunter_cmake_args(
+    fmt
+    CMAKE_ARGS
+        FMT_DOC=OFF
+        FMT_TEST=OFF
+)
+
+# Pick a download scheme
+hunter_pick_scheme(DEFAULT url_sha1_cmake) # use scheme for cmake projects
+
+# Download package.
+hunter_download(PACKAGE_NAME fmt)

--- a/examples/fmt/CMakeLists.txt
+++ b/examples/fmt/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.0)
+
+include("../common.cmake")
+
+project(download-fmt)
+
+hunter_add_package(fmt)
+
+set (CMAKE_CXX_STANDARD 11)
+
+find_package(fmt CONFIG REQUIRED)
+
+add_executable(fmtexample fmtexample.cpp)
+target_link_libraries(fmtexample fmt)

--- a/examples/fmt/fmtexample.cpp
+++ b/examples/fmt/fmtexample.cpp
@@ -1,0 +1,10 @@
+#include <fmt/format.h>
+
+int main() {
+  fmt::print("Hello world\nThis is fmt(ex-cppformat)\n");
+  auto as_string = fmt::format("The answer is {}", 42);
+  fmt::MemoryWriter w;
+  w.write("{}\nThe previous line and this message were bufferred in memory", as_string);
+  fmt::print(stderr, "{}\nAnd then were printed to stderr\n", w.c_str());
+  fmt::print("Fmt supports many nice features, see {url} for details\n", fmt::arg("url", "https://github.com/fmtlib/fmt"));
+}


### PR DESCRIPTION
fmt (previously cppformat) is a nice and fast prtintf/iostreams replacement

Url: http://fmtlib.net/

It defines two exported targets: fmt and fmt-header-only. It is slightly different from what is used in hunter usually (something like fmt::fmt and fmt::header-only), but otherwise everything works out-of-box. 