### PR TITLE
Patching HUNTER_INSTALL_PREFIX in unrelocatable text files

### DIFF
--- a/cmake/modules/hunter_save_to_cache.cmake
+++ b/cmake/modules/hunter_save_to_cache.cmake
@@ -77,6 +77,15 @@ function(hunter_save_to_cache)
       INSTALL_PREFIX "${HUNTER_PACKAGE_INSTALL_PREFIX}"
   )
 
+  # HUNTER_INSTALL_PREFIX could be present on the text file and must be replaced
+  # The cached package can be uncompressed in a different HUNTER_INSTALL_PREFIX
+  # see https://github.com/ruslo/hunter/issues/472
+  hunter_patch_unrelocatable_text_files(
+      FROM "${HUNTER_INSTALL_PREFIX}"
+      TO "__HUNTER_PACKAGE_INSTALL_PREFIX__"
+      INSTALL_PREFIX "${HUNTER_PACKAGE_INSTALL_PREFIX}"
+  )
+
   ### Lock cache directory
   set(cache_directory "${HUNTER_CACHED_ROOT}/_Base/Cache")
   hunter_lock_directory("${cache_directory}" "")

--- a/cmake/projects/drm/hunter.cmake
+++ b/cmake/projects/drm/hunter.cmake
@@ -37,7 +37,7 @@ hunter_cmake_args(
 hunter_cacheable(drm)
 hunter_download(
     PACKAGE_NAME drm
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libdrm.la"
     "lib/libdrm_amdgpu.la"

--- a/cmake/projects/ice/hunter.cmake
+++ b/cmake/projects/ice/hunter.cmake
@@ -36,7 +36,7 @@ hunter_cmake_args(
 hunter_cacheable(ice)
 hunter_download(
     PACKAGE_NAME ice
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libICE.la"
     "lib/pkgconfig/ice.pc"

--- a/cmake/projects/pciaccess/hunter.cmake
+++ b/cmake/projects/pciaccess/hunter.cmake
@@ -26,7 +26,7 @@ hunter_pick_scheme(DEFAULT url_sha1_autotools)
 hunter_cacheable(pciaccess)
 hunter_download(
     PACKAGE_NAME pciaccess
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libpciaccess.la"
     "lib/pkgconfig/pciaccess.pc"

--- a/cmake/projects/sm/hunter.cmake
+++ b/cmake/projects/sm/hunter.cmake
@@ -37,7 +37,7 @@ hunter_cmake_args(
 hunter_cacheable(sm)
 hunter_download(
     PACKAGE_NAME sm
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libSM.la"
     "lib/pkgconfig/sm.pc"

--- a/cmake/projects/x11/hunter.cmake
+++ b/cmake/projects/x11/hunter.cmake
@@ -40,7 +40,7 @@ hunter_cmake_args(
 hunter_cacheable(x11)
 hunter_download(
     PACKAGE_NAME x11
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libX11-xcb.la"
     "lib/libX11.la"

--- a/cmake/projects/xau/hunter.cmake
+++ b/cmake/projects/xau/hunter.cmake
@@ -36,6 +36,6 @@ hunter_cmake_args(
 hunter_cacheable(xau)
 hunter_download(
     PACKAGE_NAME xau
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/libXau.la;lib/pkgconfig/xau.pc"
 )

--- a/cmake/projects/xcb/hunter.cmake
+++ b/cmake/projects/xcb/hunter.cmake
@@ -46,6 +46,6 @@ hunter_pick_scheme(DEFAULT xcb)
 hunter_cacheable(xcb)
 hunter_download(
     PACKAGE_NAME xcb
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "${_xcb_text_files}"
 )

--- a/cmake/projects/xdamage/hunter.cmake
+++ b/cmake/projects/xdamage/hunter.cmake
@@ -39,7 +39,7 @@ hunter_cmake_args(
 )
 hunter_download(
     PACKAGE_NAME xdamage
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/pkgconfig/xdamage.pc"
     "lib/libXdamage.la"

--- a/cmake/projects/xext/hunter.cmake
+++ b/cmake/projects/xext/hunter.cmake
@@ -37,7 +37,7 @@ hunter_cmake_args(
 hunter_cacheable(xext)
 hunter_download(
     PACKAGE_NAME xext
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libXext.la"
     "lib/pkgconfig/xext.pc"

--- a/cmake/projects/xfixes/hunter.cmake
+++ b/cmake/projects/xfixes/hunter.cmake
@@ -39,7 +39,7 @@ hunter_cmake_args(
 hunter_cacheable(xfixes)
 hunter_download(
     PACKAGE_NAME xfixes
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libXfixes.la"
     "lib/pkgconfig/xfixes.pc"

--- a/cmake/projects/xrandr/hunter.cmake
+++ b/cmake/projects/xrandr/hunter.cmake
@@ -40,6 +40,7 @@ hunter_cmake_args(
 hunter_cacheable(xrandr)
 hunter_download(
     PACKAGE_NAME xrandr
+    PACKAGE_INTERNAL_DEPS_ID "1"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/pkgconfig/xrandr.pc"
     "lib/libXrandr.la"

--- a/cmake/projects/xrender/hunter.cmake
+++ b/cmake/projects/xrender/hunter.cmake
@@ -36,7 +36,7 @@ hunter_cmake_args(
 hunter_cacheable(xrender)
 hunter_download(
     PACKAGE_NAME xrender
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libXrender.la"
     "lib/pkgconfig/xrender.pc"

--- a/cmake/projects/xshmfence/hunter.cmake
+++ b/cmake/projects/xshmfence/hunter.cmake
@@ -35,7 +35,7 @@ hunter_cmake_args(
 hunter_cacheable(xshmfence)
 hunter_download(
     PACKAGE_NAME xshmfence
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libxshmfence.la"
     "lib/pkgconfig/xshmfence.pc"


### PR DESCRIPTION
Fix for https://github.com/ruslo/hunter/issues/472

Should I bump `PACKAGE_INTERNAL_DEPS_ID` of all autotools packages?
