### PR TITLE
Package glfw: patch unrelocatable cmake/glfw3/glfw3Targets.cmake

### DIFF
--- a/cmake/projects/glfw/hunter.cmake
+++ b/cmake/projects/glfw/hunter.cmake
@@ -21,6 +21,13 @@ hunter_pick_scheme(DEFAULT url_sha1_cmake)
 hunter_cacheable(glfw)
 hunter_download(
     PACKAGE_NAME glfw
-    PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/pkgconfig/glfw3.pc"
+    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_UNRELOCATABLE_TEXT_FILES
+    # Patching of glfw3Targets.cmake required as it has full paths due to the lack
+    # of imported targets for x11 packages. This should be removed when
+    # https://github.com/ruslo/hunter/issues/486 is implemented
+      "lib/cmake/glfw3/glfw3Targets.cmake"
+      "lib/pkgconfig/glfw3.pc"
+
 )
 


### PR DESCRIPTION
This is a workaround while https://github.com/ruslo/hunter/issues/486 is not implemented