### PR TITLE
rt library fix

### DIFF
--- a/cmake/templates/BoostConfig.cmake.in
+++ b/cmake/templates/BoostConfig.cmake.in
@@ -103,6 +103,14 @@ if(TARGET Boost::iostreams)
   include("${CMAKE_CURRENT_LIST_DIR}/BoostBZip2Dependency.cmake" OPTIONAL)
 endif()
 
+if(TARGET Boost::thread)
+  find_package(Threads REQUIRED)
+  set_property(
+    TARGET "Boost::thread"
+    APPEND PROPERTY INTERFACE_LINK_LIBRARIES Threads::Threads
+    )
+endif()
+
 if(TARGET Boost::chrono)
   include(CheckLibraryExists) # check_library_exists
   check_library_exists(rt clock_gettime "" _boost_check_rt_library)

--- a/cmake/templates/BoostConfig.cmake.in
+++ b/cmake/templates/BoostConfig.cmake.in
@@ -103,18 +103,10 @@ if(TARGET Boost::iostreams)
   include("${CMAKE_CURRENT_LIST_DIR}/BoostBZip2Dependency.cmake" OPTIONAL)
 endif()
 
-include(CheckLibraryExists) # check_library_exists
-check_library_exists(rt clock_gettime "" _boost_check_rt_library)
-
-if(TARGET Boost::thread)
-  find_package(Threads REQUIRED)
-  set_property(
-    TARGET "Boost::thread"
-    APPEND PROPERTY INTERFACE_LINK_LIBRARIES Threads::Threads rt
-    )
-endif()
-
 if(TARGET Boost::chrono)
+  include(CheckLibraryExists) # check_library_exists
+  check_library_exists(rt clock_gettime "" _boost_check_rt_library)
+
   if(_boost_check_rt_library)
       set_property(
           TARGET "Boost::chrono"

--- a/cmake/templates/BoostConfig.cmake.in
+++ b/cmake/templates/BoostConfig.cmake.in
@@ -103,10 +103,22 @@ if(TARGET Boost::iostreams)
   include("${CMAKE_CURRENT_LIST_DIR}/BoostBZip2Dependency.cmake" OPTIONAL)
 endif()
 
+include(CheckLibraryExists) # check_library_exists
+check_library_exists(rt clock_gettime "" _boost_check_rt_library)
+
 if(TARGET Boost::thread)
   find_package(Threads REQUIRED)
   set_property(
     TARGET "Boost::thread"
-    APPEND PROPERTY INTERFACE_LINK_LIBRARIES Threads::Threads
-  )
+    APPEND PROPERTY INTERFACE_LINK_LIBRARIES Threads::Threads rt
+    )
+endif()
+
+if(TARGET Boost::chrono)
+  if(_boost_check_rt_library)
+      set_property(
+          TARGET "Boost::chrono"
+          APPEND PROPERTY INTERFACE_LINK_LIBRARIES rt
+          )
+  endif()
 endif()

--- a/examples/Boost-chrono/CMakeLists.txt
+++ b/examples/Boost-chrono/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) 2013, Ruslan Baratov
+# All rights reserved.
+
+cmake_minimum_required(VERSION 3.0)
+
+# Emulate HunterGate:
+# * https://github.com/hunter-packages/gate
+include("../common.cmake")
+
+project(download-boost)
+
+# download boost
+hunter_add_package(Boost COMPONENTS system chrono)
+
+# now boost can be used
+find_package(Boost CONFIG REQUIRED system chrono)
+add_executable(foo foo.cpp)
+target_link_libraries(foo Boost::system Boost::chrono)

--- a/examples/Boost-chrono/foo.cpp
+++ b/examples/Boost-chrono/foo.cpp
@@ -1,0 +1,6 @@
+#include <boost/chrono/system_clocks.hpp>
+
+int main() {
+    boost::chrono::system_clock::now();
+    return 0;
+}


### PR DESCRIPTION
In case of some libraries (for example `boost::chrono`) it is required to link them to `librt`.
This pr contains the modification of `BoostConfig.cmake.in` and an test with `boost::chrono`.