### PR TITLE
Allow passing fPIC through to OpenSSL compile.

### DIFF
--- a/cmake/projects/OpenSSL/hunter.cmake
+++ b/cmake/projects/OpenSSL/hunter.cmake
@@ -241,4 +241,4 @@ else()
 endif()
 
 hunter_cacheable(OpenSSL)
-hunter_download(PACKAGE_NAME OpenSSL PACKAGE_INTERNAL_DEPS_ID 1)
+hunter_download(PACKAGE_NAME OpenSSL PACKAGE_INTERNAL_DEPS_ID 2)

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
@@ -33,6 +33,9 @@ else()
   set(configure_command "./config")
 endif()
 
+# Pass C flags through
+set(configure_opts ${configure_opts} ${CMAKE_C_FLAGS})
+
 set(
     configure_command
     . "@HUNTER_GLOBAL_SCRIPT_DIR@/clear-all.sh" && "${configure_command}"

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
@@ -33,6 +33,9 @@ else()
   set(configure_command "./config")
 endif()
 
+# Pass C compiler through
+set(configure_command CC=${CMAKE_C_COMPILER} ${configure_command})
+
 # Pass C flags through
 set(configure_opts ${configure_opts} ${CMAKE_C_FLAGS})
 


### PR DESCRIPTION
I wasn't able to find any way to get OpenSSL to compile with fPIC.
I tried:
- Using fPIC polly toolchain
- Setting CFLAGS, CXXFLAGS, CMAKE_CXX_FLAGS with fPIC
- Setting CMAKE_POSITION_INDEPENDENT_CODE (just because,.. I know it wouldn't work)

Passing the flag to config manually is the only way I could get this to compile on Linux.