### PR TITLE
BUILD_SHARED_LIBS triggers a dll build of OpenSSL

### DIFF
--- a/cmake/projects/OpenSSL/hunter.cmake
+++ b/cmake/projects/OpenSSL/hunter.cmake
@@ -263,4 +263,4 @@ else()
 endif()
 
 hunter_cacheable(OpenSSL)
-hunter_download(PACKAGE_NAME OpenSSL PACKAGE_INTERNAL_DEPS_ID 2)
+hunter_download(PACKAGE_NAME OpenSSL PACKAGE_INTERNAL_DEPS_ID 3)

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl_windows.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl_windows.cmake.in
@@ -73,6 +73,12 @@ else()
   set(log_opts "")
 endif()
 
+if(BUILD_SHARED_LIBS)
+    set(nt_makefile "ms\\ntdll.mak")
+else()
+    set(nt_makefile "ms\\nt.mak")
+endif()
+
 ExternalProject_Add(
     "@HUNTER_EP_NAME@"
     URL
@@ -93,12 +99,12 @@ ExternalProject_Add(
     COMMAND
     "ms\\${do_ms}"
     BUILD_COMMAND
-    nmake -f "ms\\nt.mak"
+    nmake -f "${nt_makefile}"
     BUILD_IN_SOURCE
     1
     INSTALL_COMMAND
     COMMAND
-    nmake -f "ms\\nt.mak" install
+    nmake -f "${nt_makefile}" install
     COMMAND # Copy license files
     "@CMAKE_COMMAND@"
     "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"


### PR DESCRIPTION
It seems that the hunter package for OpenSSL in windows ignore the BUILD_SHARED_LIBS argument. This commit should fix that issue.