### PR TITLE
Add support for boost shared libraries

### DIFF
--- a/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
@@ -188,8 +188,16 @@ else()
   set(copy_mpi_command "")
 endif()
 
+if(BUILD_SHARED_LIBS) #if using shared libs overide boost config
+  set(Boost_USE_STATIC_LIBS OFF)
+  if("@MSVC@")
+    set(BOOST_ALL_DYN_LINK ON)
+  endif()
+endif()
+
 if("@MSVC@")
   # Disable auto-linking
+  set(BOOST_ALL_NO_LIB 1)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DBOOST_ALL_NO_LIB=1")
 
   # Fix some compile errors
@@ -205,7 +213,11 @@ if(have_osx_sysroot)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -isysroot @CMAKE_OSX_SYSROOT@")
 endif()
 
-set(link_opts link=static)
+if(Boost_USE_STATIC_LIBS)
+	set(link_opts link=static)
+else()
+	set(link_opts link=shared)
+endif()
 
 set(toolset_full_name ${toolset_name})
 string(COMPARE NOTEQUAL "${toolset_version}" "" has_toolset_version)

--- a/cmake/templates/BoostConfig.cmake.in
+++ b/cmake/templates/BoostConfig.cmake.in
@@ -34,7 +34,6 @@ endfunction(hunter_add_rt_library)
 
 hunter_status_debug("Boost find config")
 
-set(Boost_USE_STATIC_LIBS ON)
 set(Boost_NO_BOOST_CMAKE YES)
 
 find_package(Boost MODULE REQUIRED ${Boost_FIND_COMPONENTS})
@@ -51,10 +50,16 @@ if(NOT TARGET "Boost::boost")
       INTERFACE_INCLUDE_DIRECTORIES "${_root_path}/include"
   )
   if(MSVC)
-    set_target_properties(
+    #stop MSVC from trying to auto-link libs
+	set(compile_definitions "BOOST_ALL_NO_LIB=1")
+    if(@BOOST_ALL_DYN_LINK@) #required for MSVC when using shared libs
+	  set(compile_definitions "${compile_definitions} BOOST_ALL_DYN_LINK")
+	endif()
+
+	set_target_properties(
         "Boost::boost"
         PROPERTIES
-        INTERFACE_COMPILE_DEFINITIONS "BOOST_ALL_NO_LIB=1"
+        INTERFACE_COMPILE_DEFINITIONS ${compile_definitions}
     )
   endif()
 endif()


### PR DESCRIPTION
Changes should allow for shared libraries to be built either using BUILD_SHARED_LIBS or setting Boost_USE_STATIC_LIBS to false. I attempted to setup the auto link functionality in MSVC but ending up removing it as there was no straight forward way of including the boost lib folder so MSVC could find the libs (and it didn't make sense as there would be a different config if MSVC wasn't used). I have only tested with MSVC but I don't think it makes any negative changes for others.

In the end you need to following in the CmakeLists file:

hunter_add_package(Boost COMPONENTS system filesystem)
find_package(Boost CONFIG REQUIRED system filesystem)
...
include_directories(Boost::boost)
...
add_library(exampleTest ...)
...
target_link_libraries(exampleTest Boost::system Boost::filesystem)


and in your projects hunter config:

hunter_config(Boost VERSION 1.61.0
CMAKE_ARGS 
	Boost_USE_STATIC_LIBS=OFF
	BOOST_ALL_DYN_LINK=ON
)
or

hunter_config(Boost VERSION 1.61.0
CMAKE_ARGS 
	BUILD_SHARED_LIBS=ON 
)