### PR TITLE
Fix OpenSSL builds on Android.

### DIFF
--- a/cmake/projects/OpenSSL/hunter.cmake
+++ b/cmake/projects/OpenSSL/hunter.cmake
@@ -263,4 +263,4 @@ else()
 endif()
 
 hunter_cacheable(OpenSSL)
-hunter_download(PACKAGE_NAME OpenSSL PACKAGE_INTERNAL_DEPS_ID 3)
+hunter_download(PACKAGE_NAME OpenSSL PACKAGE_INTERNAL_DEPS_ID 4)

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
@@ -33,6 +33,10 @@ else()
   set(configure_command "./config")
 endif()
 
+if(ANDROID)
+  set(configure_command MACHINE=${CMAKE_SYSTEM_PROCESSOR} RELEASE=2.6.37 SYSTEM=android ARCH=${ANDROID_ARCH_NAME} ${configure_command})
+endif()
+
 # Pass C compiler through
 set(configure_command CC=${CMAKE_C_COMPILER} ${configure_command})
 

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
@@ -12,6 +12,7 @@ list(APPEND CMAKE_MODULE_PATH "@HUNTER_SELF@/cmake/modules")
 
 include(hunter_status_debug)
 include(hunter_test_string_not_empty)
+include(hunter_user_error)
 
 hunter_status_debug("Scheme: url_sha1_openssl")
 
@@ -34,7 +35,22 @@ else()
 endif()
 
 if(ANDROID)
-  set(configure_command MACHINE=${CMAKE_SYSTEM_PROCESSOR} RELEASE=2.6.37 SYSTEM=android ARCH=${ANDROID_ARCH_NAME} ${configure_command})
+  string(COMPARE EQUAL "${CMAKE_ANDROID_ARCH}" "" _has_old_cmake)
+  string(COMPARE EQUAL "${ANDROID_ARCH_NAME}" "" _has_unexpected_toolchain)
+  if (NOT _has_old_cmake)
+    set(ANDROID_SSL_ARCH "${CMAKE_ANDROID_ARCH}")
+  elseif(NOT _has_unexpected_toolchain)
+    set(ANDROID_SSL_ARCH "${ANDROID_ARCH_NAME}")
+  else()
+    hunter_user_error("Could not find android architecture. Please set ANDROID_ARCH_NAME in your toolchain or use CMake 3.7+")
+  endif()
+  set(configure_command
+      MACHINE=${CMAKE_SYSTEM_PROCESSOR}
+      # Ignored. Prevents script from checking host uname
+      RELEASE=2.6.37
+      SYSTEM=android
+      ARCH=${ANDROID_SSL_ARCH}
+      ${configure_command})
 endif()
 
 # Pass C compiler through


### PR DESCRIPTION
OpenSSL configure script completely ignores your cross compiler environment and checks out the host system instead.
To override this requires tuning specific environmental variables.

MACHINE needs to be same format as what android toolchains set for CMAKE_SYSTEM_PROCESSOR
RELEASE is ignored but prevents it checking uname.
ARCH needs to be same format as what android toolchains set for ANDROID_ARCH_NAME. If not using a 'normal' android toolchain like polly, this may cause issues.