### PR TITLE
Disable readline requirement on Android/iOS. 

### DIFF
--- a/cmake/projects/PostgreSQL/hunter.cmake
+++ b/cmake/projects/PostgreSQL/hunter.cmake
@@ -20,6 +20,14 @@ hunter_add_version(
     b82ddcee4644ef42f3a69ee93916afa448d178c4
 )
 
+if (ANDROID OR IOS)
+  hunter_cmake_args(
+      PostgreSQL
+      CMAKE_ARGS
+          EXTRA_FLAGS=--without-readline
+  )
+endif()
+
 hunter_configuration_types(PostgreSQL CONFIGURATION_TYPES Release)
 hunter_pick_scheme(DEFAULT url_sha1_autotools)
 hunter_cacheable(PostgreSQL)


### PR DESCRIPTION
Readline is only used in the pg binary to show command history whereas we are only interested in the library for mobile devices.

This allows it to build in Travis.