### PR TITLE
Fix an issue in OpenSSL build when cross compiling

### DIFF
--- a/cmake/projects/OpenSSL/hunter.cmake
+++ b/cmake/projects/OpenSSL/hunter.cmake
@@ -263,4 +263,4 @@ else()
 endif()
 
 hunter_cacheable(OpenSSL)
-hunter_download(PACKAGE_NAME OpenSSL PACKAGE_INTERNAL_DEPS_ID 4)
+hunter_download(PACKAGE_NAME OpenSSL PACKAGE_INTERNAL_DEPS_ID 5)

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
@@ -45,7 +45,6 @@ if(ANDROID)
     hunter_user_error("Could not find android architecture. Please set ANDROID_ARCH_NAME in your toolchain or use CMake 3.7+")
   endif()
   set(configure_command
-      MACHINE=${CMAKE_SYSTEM_PROCESSOR}
       # Ignored. Prevents script from checking host uname
       RELEASE=2.6.37
       SYSTEM=android
@@ -54,7 +53,10 @@ if(ANDROID)
 endif()
 
 # Pass C compiler through
-set(configure_command CC=${CMAKE_C_COMPILER} ${configure_command})
+set(configure_command 
+    MACHINE=${CMAKE_SYSTEM_PROCESSOR}
+    CC=${CMAKE_C_COMPILER}
+    ${configure_command})
 
 # Pass C flags through
 set(configure_opts ${configure_opts} ${CMAKE_C_FLAGS})


### PR DESCRIPTION
The commit 44c681e1a551e0599a8ca170cb0cfcc19c4a5d54 seems to have
broken cross compiling builds, as openssl ./config seems to require
both the CC and MACHINE variables to be set, otherwise it seems to
default to build host compiler and machine variables.  Someone appears
to have already seen this issue when cross compiling for android, and
fixed it in commit bb657ff41c874ca3bba1ca394ff1ea09ee8049b3.  This
patch moves the MACHINE argument and adds it to ALL build types, not
just android.


I'm unclear on the architecture of the PACKAGE_INTERNAL_DEPS_ID, but I saw it being incremented for other similar changes, so I assume this will require an update as well.  If I'm wrong, let me know and I will update the PR.