### PR TITLE
Update cmake-dependencies: fix typos, clarify

### DIFF
--- a/docs/creating-new/cmake-dependencies.rst
+++ b/docs/creating-new/cmake-dependencies.rst
@@ -4,9 +4,9 @@
 CMake (with dependencies)
 -------------------------
 
-If your project use external packages (i.e. has command ``find_package(Foo)``)
-you need to patch it first so this packages can be found in Hunter root
-directory instead of standard one:
+If your project uses external packages (i.e. has command ``find_package(Foo)``)
+you need to patch it first so these packages can be found in the Hunter root
+directory instead of the standard one:
 
 .. code-block:: cmake
   :emphasize-lines: 1
@@ -19,11 +19,12 @@ directory instead of standard one:
 Conflict
 ========
 
-The reason is that if one package will be found in standard location and other
-in Hunter they may conflict with each other.
+Without the ``hunter_add_package(Foo)`` call one package will be found in the
+standard location and another one in the Hunter root directory. The found
+packages may may conflict with each other.
 
-Consider next example. Project ``Roo`` is not aware about Hunter custom
-locations. It just using regular ``find_package``:
+Consider the next example: Project ``Roo`` is not aware about Hunter custom
+locations. It's just using regular ``find_package``:
 
 .. code-block:: cmake
 
@@ -31,7 +32,7 @@ locations. It just using regular ``find_package``:
 
   find_package(ZLIB)
 
-Project ``Bar`` depends on ``ZLIB`` and ``Roo``. Both packages downloaded by
+Project ``Bar`` depends on ``ZLIB`` and ``Roo``. Both packages are downloaded by
 ``hunter_add_package`` commands:
 
 .. code-block:: cmake
@@ -51,7 +52,7 @@ Project ``Bar`` depends on ``ZLIB`` and ``Roo``. Both packages downloaded by
 Fix
 ===
 
-To fix this issue you need to patch ``Roo`` so it will use ``ZLIB`` from Hunter.
+To fix this issue you need to patch project ``Roo`` so it will use ``ZLIB`` from Hunter.
 In terms of CMake code it means adding ``HunterGate`` and ``hunter_add_package``
 (see :doc:`First Step </quick-start/boost-components>`):
 
@@ -68,42 +69,42 @@ In terms of CMake code it means adding ``HunterGate`` and ``hunter_add_package``
 .. image:: /images/package-conflict-resolved.png
   :align: center
 
-Note that SHA1 of Hunter archive in ``HunterGate`` commands of ``Bar`` and
+Note that the SHA1 of the Hunter archive in ``HunterGate`` commands of ``Bar`` and
 ``Roo`` can be different. Same location will be set automatically internally
 you don't have to manage it manually.
 
 Maintenance
 ===========
 
-On practice patching require to have a fork of a project.  In general it
-doesn't matter where fork is located but there is a central place for the
+In practice patching requires to have a fork of a project.  In general it
+doesn't matter where the fork is located. But it matters that there is a central place for the
 patched packages:
 
 * https://github.com/hunter-packages
 
-If you want to create new fork let me know about it in corresponding issue
+If you want to create new fork let me know about it in a corresponding issue
 with `"new package" label`_, I will create a new team and add you so you can
-push changed. New branch ``hunter`` will be created for patching, please
+push changes. Create a new branch ``hunter`` for patching. Please
 keep other branches in a **clean state** so we can always do
 ``git merge --ff-only`` from upstream.
 Please do push commits **only related to hunterization**. Do not push general
 fixes and improvements, do push them **upstream** instead. Perfect hunterization
-should contains only:
+should contain only:
 
 * Adding ``HunterGate`` module (`example <https://github.com/hunter-packages/opencv/commit/a5d663884a186c8dfdabb9dcae92defd32d28329?diff=unified>`__)
 * Including it with some URL/SHA1 (`example <https://github.com/hunter-packages/opencv/commit/f1d4605e9e50cc0e45cb74c26ce24e094ee16bc5?diff=unified>`__)
 * Adding ``hunter_add_package`` commands (`example <https://github.com/hunter-packages/opencv/commit/b65ec7f719d1da17c01b154a847d2b89cfbaacb8?diff=unified>`__)
 
-Note that I'm not willing and can't do maintain all packages on practice so
+Note that I'm not willing and can't maintain all packages in practice. Therefore
 I do add all developers to the team if they ask to. If you want to be
 a maintainer, keep eye on changes, pull requests, be responsible for review and
 releases - let me know.
 
-Also note that Hunter designed to have **zero maintenance** for such task since
+Also note that Hunter is designed to have **zero maintenance** for such tasks, since
 you can add ``HUNTER_ENABLED=OFF`` option at the top of the project to skip all
 package management stuff (see :doc:`/overview/compatibility`).  It means you
 can push branch ``hunter`` to upstream without affecting functionality of
-the project. As a summary it may sounds strange but the final goal of this
-organization is to have no packages at all.
+the project. As a summary it may sounds strange, but the final goal of this
+organization is to have no forks of packages at all.
 
 .. _"new package" label: https://github.com/ruslo/hunter/issues?q=is%3Aopen+is%3Aissue+label%3A%22new+package%22


### PR DESCRIPTION
I don't understand what you want to say with the following paragraph

```
Note that the SHA1 of the Hunter archive in ``HunterGate`` commands of ``Bar`` and
 ``Roo`` can be different. Same location will be set automatically internally
 you don't have to manage it manually.
```

Do you mean, that the huntergate of the top project will be used for the submodule?