### PR TITLE
Boost: use base url for official releases

### DIFF
--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -12,13 +12,16 @@ include(hunter_pick_scheme)
 # Disable searching in locations not specified by these hint variables.
 set(Boost_NO_SYSTEM_PATHS ON)
 
+# use base url for official boost releases
+set(Boost_base_url "https://downloads.sourceforge.net/project/boost/boost/")
+
 hunter_add_version(
     PACKAGE_NAME
     Boost
     VERSION
     "1.63.0"
     URL
-    "https://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.tar.bz2"
+    "${Boost_base_url}/1.63.0/boost_1_63_0.tar.bz2"
     SHA1
     9f1dd4fa364a3e3156a77dc17aa562ef06404ff6
 )
@@ -29,7 +32,7 @@ hunter_add_version(
     VERSION
     "1.62.0"
     URL
-    "https://downloads.sourceforge.net/project/boost/boost/1.62.0/boost_1_62_0.tar.bz2"
+    "${Boost_base_url}/1.62.0/boost_1_62_0.tar.bz2"
     SHA1
     5fd97433c3f859d8cbab1eaed4156d3068ae3648
 )
@@ -41,7 +44,7 @@ hunter_add_version(
     VERSION
     "1.61.0"
     URL
-    "https://downloads.sourceforge.net/project/boost/boost/1.61.0/boost_1_61_0.tar.bz2"
+    "${Boost_base_url}/1.61.0/boost_1_61_0.tar.bz2"
     SHA1
     f84b1a1ce764108ec3c2b7bd7704cf8dfd3c9d01
 )

--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -13,7 +13,7 @@ include(hunter_pick_scheme)
 set(Boost_NO_SYSTEM_PATHS ON)
 
 # use base url for official boost releases
-set(Boost_base_url "https://downloads.sourceforge.net/project/boost/boost/")
+set(_hunter_boost_base_url "https://downloads.sourceforge.net/project/boost/boost/")
 
 hunter_add_version(
     PACKAGE_NAME
@@ -21,7 +21,7 @@ hunter_add_version(
     VERSION
     "1.63.0"
     URL
-    "${Boost_base_url}/1.63.0/boost_1_63_0.tar.bz2"
+    "${_hunter_boost_base_url}/1.63.0/boost_1_63_0.tar.bz2"
     SHA1
     9f1dd4fa364a3e3156a77dc17aa562ef06404ff6
 )
@@ -32,7 +32,7 @@ hunter_add_version(
     VERSION
     "1.62.0"
     URL
-    "${Boost_base_url}/1.62.0/boost_1_62_0.tar.bz2"
+    "${_hunter_boost_base_url}/1.62.0/boost_1_62_0.tar.bz2"
     SHA1
     5fd97433c3f859d8cbab1eaed4156d3068ae3648
 )
@@ -44,7 +44,7 @@ hunter_add_version(
     VERSION
     "1.61.0"
     URL
-    "${Boost_base_url}/1.61.0/boost_1_61_0.tar.bz2"
+    "${_hunter_boost_base_url}/1.61.0/boost_1_61_0.tar.bz2"
     SHA1
     f84b1a1ce764108ec3c2b7bd7704cf8dfd3c9d01
 )


### PR DESCRIPTION
I'd like to propose the use of base urls for official releases.

I have build machines not connected to the internet using hunter. I provide a LAN available web server with the official released tar balls. I have to modify hunter for every new release of an internal used package. With this change I could easily integrate new releases