### PR TITLE
opencv 3.0.0-p9

### DIFF
--- a/cmake/projects/OpenCV/hunter.cmake
+++ b/cmake/projects/OpenCV/hunter.cmake
@@ -50,6 +50,17 @@ hunter_add_version(
     PACKAGE_NAME
     OpenCV
     VERSION
+    "3.0.0-p9"
+    URL
+    "https://github.com/hunter-packages/opencv/archive/v3.0.0-p9.tar.gz"
+    SHA1
+    b41a71206d0963dcdf934ecf8f0d7ff299c4b57c
+)  
+
+hunter_add_version(
+    PACKAGE_NAME
+    OpenCV
+    VERSION
     "3.0.0-p8"
     URL
     "https://github.com/hunter-packages/opencv/archive/v3.0.0-p8.tar.gz"


### PR DESCRIPTION
fixes for native cmake android toolchain (>= 3.7.1)