### PR TITLE
index.rst: split into paragraphs; general copyedit

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,31 +13,37 @@ Hunter: organize freedom
 
 Welcome to the Hunter package manager documentation!
 
-Hunter is CMake-driven cross-platform package manager for C++ [1]_ projects.
+Hunter is a CMake-driven cross-platform package manager for C++ [1]_ projects.
 With the help of Hunter you can organize builds for **Linux**, **OS X**,
-**Windows**, **iOS**, **Android**, **Raspberry Pi**. Third party external
-projects are highly customizable effectively allowing you to have myriad
+**Windows**, **iOS**, **Android**, and **Raspberry Pi**. Third-party external
+projects are highly customizable, effectively allowing you to have myriad
 variants of directories with them based on combinations of version to build,
-static/shared, CMake ``-D`` options, Release/Debug etc.  Separate root
-directory will be created for each variant so they all can be used
-simultaneously on one machine without conflicts (just like `virtualenv`_ but
-automatically).  Going further: each such root directory can be shared between
-several local projects if configuration of externals matches. So when you are
-starting project from scratch and use same external packages there will be no
-additional copy or build triggered, the only overhead is checking existence of
-one ``DONE`` stamp file for each package. In case your local environment is
-similar enough to continuous integration environment of Travis/AppVeyor
-services then build will not be triggered at all - cached binaries will be
-downloaded from GitHub server instead. Mainly Hunter designed to manage
-packages with CMake build system under the hood and existing CMake package can
-be quite easily integrated into system but non-CMake packages supported too
-using custom templates (build schemes) with ``ExternalProject_Add`` command(s).
-Client is a collection of CMake only modules (i.e. it's **not a binary** like
-``apt-get`` or script like ``brew``) so it supports from the box all
-platforms/generators/IDEs which CMake can handle like Visual Studio, Xcode,
-QtCreator, NMake, Ninja, Cygwin or MinGW.  Works fine with CMake-GUI too.
+static/shared, CMake ``-D`` options, Release/Debug, etc.
 
-Prime directive used for adding package to the current root is
+Separate root directories will be created for each variant, so they all
+can be used simultaneously on one machine without conflicts
+(just like `virtualenv`_ but automatically).
+Going further: each such root directory can be shared between several
+local projects if configuration of externals matches.
+So when you are starting another project from scratch and use the same external
+packages, there will be no additional copy or build triggered; the only
+overhead is checking the existence of a ``DONE`` stamp file for each package.
+In case your local environment is similar enough to the continuous integration
+environment of Travis/AppVeyor service, then build will not be triggered at all
+- cached binaries will be downloaded from GitHub server instead.
+
+Mainly Hunter is designed to manage packages with CMake build system under the
+hood and existing CMake packages can be quite easily integrated into system,
+but non-CMake packages are also supported too using custom templates
+(build schemes) with ``ExternalProject_Add`` command(s).
+
+The Hunter client is a collection of CMake-only modules
+(i.e. it's **not a binary** like ``apt-get`` or script like ``brew``)
+so it supports out-of-the-box all platforms/generators/IDEs which CMake can
+handle, like Visual Studio, Xcode, QtCreator, NMake, Ninja, Cygwin or MinGW.
+It works fine with CMake-GUI too.
+
+The prime directive used for adding package to the current root is
 ``hunter_add_package`` which companioning CMake's ``find_package``. For
 example:
 


### PR DESCRIPTION
Breaking a large block of text into paragraphs makes it easier to read. Also, some minor English issues were fixed.

By the way: is there a guide to how people can contribute to finalize the migration of the docs from the wiki? The warning on this page provides no indication of what needs to be done.