### PR TITLE
Remove CUDA from default compile of OpenCV

### DIFF
--- a/cmake/projects/OpenCV/hunter.cmake
+++ b/cmake/projects/OpenCV/hunter.cmake
@@ -303,6 +303,10 @@ hunter_cmake_args(
         BUILD_opencv_java=OFF
         BUILD_opencv_python2=OFF
         BUILD_opencv_python3=OFF
+        # There is not a CUDA package so need to stop OpenCV from searching for it, otherwise
+        #  it might pick up the host version
+        WITH_CUDA=OFF
+        WITH_CUFFT=OFF
 )
 
 # Pick a download scheme


### PR DESCRIPTION
This removes CUDA from OpenCV's default compile. Since there is no package for CUDA yet, OpenCV's cmake setup will search the host system for the SDK and attempt to compile with it.