### PR TITLE
pkg-config search path overridden to <root-id>/{lib,share}/pkconfig

### DIFF
--- a/cmake/modules/hunter_autotools_project.cmake
+++ b/cmake/modules/hunter_autotools_project.cmake
@@ -8,7 +8,7 @@
 #
 # Adds to the environment variables:
 #   PATH=<root-id>/bin
-#   PKG_CONFIG_PATH=<root-id>/{lib,share}/pkgconfig
+#   PKG_CONFIG_LIBDIR=<root-id>/{lib,share}/pkgconfig
 #
 # Adds to autotools flags:
 #   CPPFLAGS=-I<root-id>/include
@@ -315,10 +315,11 @@ function(hunter_autotools_project target_name)
       "PATH=${PARAM_GLOBAL_INSTALL_DIR}/bin:${default_path}"
   )
 
-  # PKG_CONFIG_PATH environment variable
+  # PKG_CONFIG_LIBDIR environment variable
+  # This info is also in hunter_finalize.cmake
   set(d1 "${PARAM_GLOBAL_INSTALL_DIR}/lib/pkgconfig")
   set(d2 "${PARAM_GLOBAL_INSTALL_DIR}/share/pkgconfig")
-  list(APPEND configure_command "PKG_CONFIG_PATH=${d1}:${d2}")
+  list(APPEND configure_command "PKG_CONFIG_LIBDIR=${d1}:${d2}")
 
   string(COMPARE NOTEQUAL "${PARAM_BOOTSTRAP}" "" have_bootstrap)
   if(have_bootstrap)

--- a/cmake/modules/hunter_finalize.cmake
+++ b/cmake/modules/hunter_finalize.cmake
@@ -78,6 +78,16 @@ macro(hunter_finalize)
 
   set(HUNTER_INSTALL_PREFIX "${HUNTER_TOOLCHAIN_ID_PATH}/Install")
   list(APPEND CMAKE_PREFIX_PATH "${HUNTER_INSTALL_PREFIX}")
+
+  # Override pkg-config default search path
+  # https://github.com/ruslo/hunter/issues/762
+  if(NOT MSVC)
+    set(_pkg_config_dir1 "${HUNTER_INSTALL_PREFIX}/lib/pkgconfig")
+    set(_pkg_config_dir2 "${HUNTER_INSTALL_PREFIX}/share/pkgconfig")
+    # This info is also in hunter_autotools_project.cmake
+    set(ENV{PKG_CONFIG_LIBDIR} "${_pkg_config_dir1}:${_pkg_config_dir2}")
+  endif()
+
   if(ANDROID)
     # OpenCV support: https://github.com/ruslo/hunter/issues/153
     list(APPEND CMAKE_PREFIX_PATH "${HUNTER_INSTALL_PREFIX}/sdk/native/jni")

--- a/cmake/projects/OpenCV/hunter.cmake
+++ b/cmake/projects/OpenCV/hunter.cmake
@@ -330,4 +330,7 @@ hunter_pick_scheme(DEFAULT url_sha1_cmake)
 #     * libexample_Ad.a
 
 hunter_cacheable(OpenCV)
-hunter_download(PACKAGE_NAME OpenCV)
+hunter_download(
+    PACKAGE_NAME OpenCV
+    PACKAGE_INTERNAL_DEPS_ID "1"
+)


### PR DESCRIPTION
Hi Ruslan, 

You think that maybe it should be guarded with `if(NOT MSVC)`?

```CMake
if(NOT MSVC)
  set(ENV{PKG_CONFIG_LIBDIR} ...)
endif()
```

Should the string containing the paths be split up in 2 variables as the one in the `hunter_autotools_project.cmake` to make it shorter? I just didn't do that way to not pollute the global namespace.

Small change, but with big impact, would be nice to run tests on all packages :->

Thanks