### PR TITLE
examples: don't use cache servers for testing

### DIFF
--- a/examples/common.cmake
+++ b/examples/common.cmake
@@ -3,6 +3,9 @@
 
 cmake_minimum_required(VERSION 3.0)
 
+# don't use cache servers
+set(HUNTER_USE_CACHE_SERVERS NO)
+
 ### Include HunterGate module from git submodule
 set(gate_dir "${CMAKE_CURRENT_LIST_DIR}/../gate")
 set(gate_module "${gate_dir}/cmake/HunterGate.cmake")


### PR DESCRIPTION
The examples are used for testing. Is it intended, that these tests use the cache server instead of really compiling the packages?
If it was not intended this patch disables the use of hunter cache servers