### PR TITLE
Support for cache servers different than github

### DIFF
--- a/cmake/modules/hunter_download_cache_meta_file.cmake
+++ b/cmake/modules/hunter_download_cache_meta_file.cmake
@@ -65,19 +65,20 @@ function(hunter_download_cache_meta_file)
     foreach(server ${HUNTER_CACHE_SERVERS})
       string(REGEX MATCH "^https://github.com/" is_github "${server}")
       if(NOT is_github)
-        hunter_user_error("Unknown cache server: ${server}")
+        set(local_url "${server}/meta/${local_suffix}")
+        set(done_url "${server}/meta/${done_suffix}")
+      else()
+        string(
+            REPLACE
+            "https://github.com/"
+            "https://raw.githubusercontent.com/"
+            url
+            "${server}"
+        )
+          
+        set(local_url "${url}/master/${local_suffix}")
+        set(done_url "${url}/master/${done_suffix}")
       endif()
-
-      string(
-          REPLACE
-          "https://github.com/"
-          "https://raw.githubusercontent.com/"
-          url
-          "${server}"
-      )
-
-      set(local_url "${url}/master/${local_suffix}")
-      set(done_url "${url}/master/${done_suffix}")
 
       hunter_status_debug("Downloading file (try #${x} of ${total_retry}):")
       hunter_status_debug("  ${done_url}")

--- a/cmake/modules/hunter_download_cache_raw_file.cmake
+++ b/cmake/modules/hunter_download_cache_raw_file.cmake
@@ -71,10 +71,10 @@ function(hunter_download_cache_raw_file)
     foreach(server ${HUNTER_CACHE_SERVERS})
       string(REGEX MATCH "^https://github.com/" is_github "${server}")
       if(NOT is_github)
-        hunter_user_error("Unknown cache server: ${server}")
+        set(url "${server}/raw/${suffix}")
+      else()
+        set(url "${server}/releases/download/cache/${suffix}")
       endif()
-
-      set(url "${server}/releases/download/cache/${suffix}")
 
       hunter_status_debug("Downloading file (try #${x} of ${total_retry}):")
       hunter_status_debug("  ${url}")

--- a/docs/user-guides/hunter-user.rst
+++ b/docs/user-guides/hunter-user.rst
@@ -8,6 +8,7 @@ Hunter user
    :maxdepth: 1
 
    /user-guides/hunter-user/git-submodule
+   /user-guides/hunter-user/nexus-cache-server
 
 TODO
 ====

--- a/docs/user-guides/hunter-user/nexus-cache-server.rst
+++ b/docs/user-guides/hunter-user/nexus-cache-server.rst
@@ -1,0 +1,50 @@
+Using Nexus Repository manager as binary cache server
+------------------------------
+
+Hunter allows to upload binary cache to any server. If you want to use `github <https://github.com>`__
+as a cache server, then you can execute `python script <https://github.com/ruslo/hunter/blob/master/maintenance/upload-cache-to-github.py>`__
+which is uploading cache binaries to `github <https://github.com>`__
+directly. As an alternative you can also use ``Nexus Repository Manager``.
+
+Nexus installation
+=================================
+
+In order to install and configure Nexus Repository Manager, please follow official Sonartype `documentation. <https://books.sonatype.com/nexus-book/reference/install.html>`__
+There is also possibility do download ``docker images`` with preinstalled Nexus Repository Manager:
+
+* Nexus Repository Manager 2: https://github.com/sonatype/docker-nexus
+
+* Nexus Repository Manager 3: https://github.com/sonatype/docker-nexus3
+
+Nexus adding, configuring and managing repositories
+=================================
+
+To create new or manage existing repository follow this links:
+
+* Adding a new repository: https://books.sonatype.com/nexus-book/reference/config-sect-new-repo.html
+
+* Managing repositories: https://books.sonatype.com/nexus-book/reference/confignx-sect-manage-repo.html
+
+* Configuring repositories: https://books.sonatype.com/nexus-book/reference/confignx-sect-manage-repo.html#_configuring_repositories
+
+Uploading cache binaries to Nexus
+=================================
+
+The simplest way to upload local cache binaries to Nexus server is by using ``curl``:
+
+.. code-block:: bash
+
+   $ cd hunter/_Base/Cache/meta
+   $ CACHE_REPOSITORY_URL="http://my.nexus.server.com/content/repositories/hunter/cache"
+   $ find ./ -type f -exec curl -u nexuser:nexpwd --upload-file "{}" "$CACHE_REPOSITORY_URL/meta/{}"
+   $ cd ../raw
+   $ find ./ -type f -exec curl -u nexuser:nexpwd --upload-file "{}" "$CACHE_REPOSITORY_URL/raw/{}"
+
+Configuring Hunter to use Nexus
+=================================
+
+To configure ``Hunter`` to use ``Nexus`` server, you must perform the following step:
+
+.. code-block:: cmake
+
+   list(APPEND HUNTER_CACHE_SERVERS "http://my.nexus.server.com/content/repositories/hunter/cache")

--- a/docs/user-guides/hunter-user/nexus-cache-server.rst
+++ b/docs/user-guides/hunter-user/nexus-cache-server.rst
@@ -1,5 +1,5 @@
 Using Nexus Repository manager as binary cache server
-------------------------------
+-----------------------------------------------------
 
 Hunter allows to upload binary cache to any server. If you want to use `github <https://github.com>`__
 as a cache server, then you can execute `python script <https://github.com/ruslo/hunter/blob/master/maintenance/upload-cache-to-github.py>`__
@@ -7,7 +7,7 @@ which is uploading cache binaries to `github <https://github.com>`__
 directly. As an alternative you can also use ``Nexus Repository Manager``.
 
 Nexus installation
-=================================
+==================
 
 In order to install and configure Nexus Repository Manager, please follow official Sonartype `documentation. <https://books.sonatype.com/nexus-book/reference/install.html>`__
 There is also possibility do download ``docker images`` with preinstalled Nexus Repository Manager:
@@ -17,7 +17,7 @@ There is also possibility do download ``docker images`` with preinstalled Nexus 
 * Nexus Repository Manager 3: https://github.com/sonatype/docker-nexus3
 
 Nexus adding, configuring and managing repositories
-=================================
+===================================================
 
 To create new or manage existing repository follow this links:
 
@@ -41,7 +41,7 @@ The simplest way to upload local cache binaries to Nexus server is by using ``cu
    $ find ./ -type f -exec curl -u nexuser:nexpwd --upload-file "{}" "$CACHE_REPOSITORY_URL/raw/{}"
 
 Configuring Hunter to use Nexus
-=================================
+===============================
 
 To configure ``Hunter`` to use ``Nexus`` server, you must perform the following step:
 

--- a/docs/user-guides/hunter-user/nexus-cache-server.rst
+++ b/docs/user-guides/hunter-user/nexus-cache-server.rst
@@ -9,8 +9,8 @@ directly. As an alternative you can also use ``Nexus Repository Manager``.
 Nexus installation
 ==================
 
-In order to install and configure Nexus Repository Manager, please follow official Sonartype `documentation. <https://books.sonatype.com/nexus-book/reference/install.html>`__
-There is also possibility do download ``docker images`` with preinstalled Nexus Repository Manager:
+In order to install and configure Nexus Repository Manager, please follow official `documentation. <https://books.sonatype.com/nexus-book/reference/install.html>`__
+There is also possibility do download ``docker images`` where ``Nexus Repository Manager`` is already installed:
 
 * Nexus Repository Manager 2: https://github.com/sonatype/docker-nexus
 


### PR DESCRIPTION
## Reason
As a developer sometimes I need to work with **local cache server** (usually nexus), so far there is restriction to support only github. So it would be nice to set **HUNTER_CACHE_SERVERS** in order to use local nexus server.

## Example
For example I have following nexus folder structure:
					

http://my-local-nexus.com/content/sites/hunter/cache
│   ├── meta/
│   ├── db0d7e2
│   │   ├── Boost
│   │   └── OpenSSL
│   └── f87f14b
│   │    ├── Boost
│    │   └── OpenSSL
...
├── raw/
 │   ├── 02f24b4519e47ed326979d4054fcde35f90e1e1e.tar.bz2
 │   ├── 3309ab7e3e7f82b7a1f275148fbee24b9a1ab35a.tar.bz2
  │  └── 50655f24090c8e1bbedcac2062e4d2eb45205211.tar.bz2
...

## Solution
We need only to extend server list like that:

list(APPEND **HUNTER_CACHE_SERVERS** "http://my-local-nexus.com/content/sites/hunter/cache")