### PR TITLE
Fix OpenSSL compile on Android. Fixes CFLAG mangling in config script.

### DIFF
--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
@@ -31,6 +31,8 @@ hunter_test_string_not_empty("@HUNTER_GLOBAL_SCRIPT_DIR@")
 if(APPLE)
   set(configure_command "./Configure")
   set(configure_opts "darwin64-x86_64-cc")
+elseif(ANDROID)
+  set(configure_command "./Configure")
 else()
   set(configure_command "./config")
 endif()
@@ -55,11 +57,17 @@ if(ANDROID)
   # Set environment variables similar to 'setenv-android.sh' script:
   # * https://wiki.openssl.org/index.php/Android#Adjust_the_Cross-Compile_Script
   set(configure_command
-      # Ignored. Prevents script from checking host uname
-      RELEASE=2.6.37
-      SYSTEM=android
-      ARCH=${ANDROID_SSL_ARCH}
-      ${configure_command})
+      ${configure_command} ${CMAKE_C_FLAGS})
+
+  # Latest OpenSSL (1.1.1) still does not have correct android targets, so set generic with our CFLAGS
+  string(COMPARE EQUAL "${ANDROID_SSL_ARCH}" "arm64" _is_arm64)
+  string(COMPARE EQUAL "${ANDROID_SSL_ARCH}" "mips64" _is_mips64)
+  string(COMPARE EQUAL "${ANDROID_SSL_ARCH}" "x86_64" _is_x8664)
+  if (_is_arm64 OR _is_mips64 OR _is_x8664)
+    set(configure_opts "linux-generic64")
+  else()
+    set(configure_opts "linux-generic32")
+  endif()
 endif()
 
 # Pass C compiler through
@@ -68,8 +76,6 @@ set(configure_command
     CC=${CMAKE_C_COMPILER}
     ${configure_command})
 
-# Pass C flags through
-set(configure_opts ${configure_opts} ${CMAKE_C_FLAGS})
 
 set(
     configure_command

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
@@ -56,10 +56,6 @@ if(ANDROID)
   # * https://wiki.openssl.org/index.php/Android#Build_the_OpenSSL_Library
   # Set environment variables similar to 'setenv-android.sh' script:
   # * https://wiki.openssl.org/index.php/Android#Adjust_the_Cross-Compile_Script
-  set(configure_command
-      ${configure_command} ${CMAKE_C_FLAGS})
-
-  # Latest OpenSSL (1.1.1) still does not have correct android targets, so set generic with our CFLAGS
   string(COMPARE EQUAL "${ANDROID_SSL_ARCH}" "arm64" _is_arm64)
   string(COMPARE EQUAL "${ANDROID_SSL_ARCH}" "mips64" _is_mips64)
   string(COMPARE EQUAL "${ANDROID_SSL_ARCH}" "x86_64" _is_x8664)
@@ -76,6 +72,8 @@ set(configure_command
     CC=${CMAKE_C_COMPILER}
     ${configure_command})
 
+# Pass C flags through
+set(configure_opts ${configure_opts} ${CMAKE_C_FLAGS})
 
 set(
     configure_command


### PR DESCRIPTION
The OpenSSL config script runs a s/^--/- script that ruins our CFLAGS input.
The Android config uses -mandroid that doesn't work on clang.


As a solution, use our CFLAGS on top of a generic linux config and use the proper Configure script.

As far as I know, Configure should be used when you are bringing your own CFLAGS and config should be used to automatically set up sane flags.
For Android, the latter is not working very well.

With this change, Android now compiles for all versions of OpenSSL on GCC and Clang.