### PR TITLE
Workaround for three known issues in OpenSSL for Android.

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -84,8 +84,7 @@ hunter_config(OpenCL-cpp VERSION 2.0.10-p0)
 hunter_config(OpenCV VERSION 3.2.0-p1)
 hunter_config(OpenCV-Extra VERSION 3.0.0)
 hunter_config(OpenNMTTokenizer VERSION 0.2.0-p1)
-if(MSVC OR ANDROID)
-  # FIXME: https://travis-ci.org/ingenue/hunter/jobs/215460184
+if(MSVC)
   # FIXME: https://ci.appveyor.com/project/ingenue/hunter/build/1.0.1470
   hunter_config(OpenSSL VERSION 1.0.2l)
 else()

--- a/cmake/projects/OpenSSL/hunter.cmake
+++ b/cmake/projects/OpenSSL/hunter.cmake
@@ -307,4 +307,4 @@ else()
 endif()
 
 hunter_cacheable(OpenSSL)
-hunter_download(PACKAGE_NAME OpenSSL PACKAGE_INTERNAL_DEPS_ID "10")
+hunter_download(PACKAGE_NAME OpenSSL PACKAGE_INTERNAL_DEPS_ID "11")

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
@@ -31,6 +31,12 @@ hunter_test_string_not_empty("@HUNTER_GLOBAL_SCRIPT_DIR@")
 if(APPLE)
   set(configure_command "./Configure")
   set(configure_opts "darwin64-x86_64-cc")
+elseif(ANDROID)
+  # Using the ./config script is currently broken with -no* CFLAGS on ALL versions
+  # * https://github.com/openssl/openssl/issues/3493
+  # * https://github.com/openssl/openssl/blob/OpenSSL_1_1_0-stable/Configure#L560
+  # * https://wiki.openssl.org/index.php/Compilation_and_Installation#Configure_.26_Config
+  set(configure_command "./Configure")
 else()
   set(configure_command "./config")
 endif()
@@ -54,12 +60,24 @@ if(ANDROID)
   # * https://wiki.openssl.org/index.php/Android#Build_the_OpenSSL_Library
   # Set environment variables similar to 'setenv-android.sh' script:
   # * https://wiki.openssl.org/index.php/Android#Adjust_the_Cross-Compile_Script
-  set(configure_command
-      # Ignored. Prevents script from checking host uname
-      RELEASE=2.6.37
-      SYSTEM=android
-      ARCH=${ANDROID_SSL_ARCH}
-      ${configure_command})
+
+  # Using documented method (./config script):
+  #set(configure_command
+      # Ignored. Prevents ./config from checking host uname
+  #   RELEASE=2.6.37
+  #   SYSTEM=android
+  #   ARCH=${CMAKE_ANDROID_ARCH}
+  #   ${configure_command})
+
+  # Using android-* targets is currently broken for Clang on ALL versions
+  # * https://github.com/openssl/openssl/pull/2229
+  # The ./config script only detects Android x86 and armv7 targets anyway.
+  # * https://github.com/openssl/openssl/issues/2490
+  if (CMAKE_ANDROID_ARCH MATCHES "mips64|arm64|x86_64")
+    set(configure_opts "linux-generic64")
+  else()
+    set(configure_opts "linux-generic32")
+  endif()
 endif()
 
 # Pass C compiler through

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
@@ -73,7 +73,7 @@ if(ANDROID)
   # * https://github.com/openssl/openssl/pull/2229
   # The ./config script only detects Android x86 and armv7 targets anyway.
   # * https://github.com/openssl/openssl/issues/2490
-  if (CMAKE_ANDROID_ARCH MATCHES "mips64|arm64|x86_64")
+  if (ANDROID_SSL_ARCH MATCHES "mips64|arm64|x86_64")
     set(configure_opts "linux-generic64")
   else()
     set(configure_opts "linux-generic32")


### PR DESCRIPTION
1. The OpenSSL Configure script runs a s/^-no-/no- script that ruins our CFLAGS input when input from ./config.
On this line: https://github.com/openssl/openssl/blob/OpenSSL_1_1_0-stable/Configure#L560
Tracked here: openssl/openssl#3493

2. The android-* targets use -mandroid that doesn't work on clang.
To be fixed in future versions with this pull: openssl/openssl#2229

3. ./config can only set up x86 and armv7 targets. It ignores armv8, mips32, mips64 and x86_64.
Tracked here: https://github.com/openssl/openssl/issues/2490

As a solution, use our CFLAGS on top of a generic linux target and use the main Configure script.

As far as I know, Configure should be used when you are bringing your own CFLAGS and config should be used to automatically set up sane flags.
For Android, the latter is not working very well.

With this change, Android now compiles for all versions of OpenSSL on GCC and Clang.