### PR TITLE
Update mysql to 1.6.9-p0, adds install config

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -79,7 +79,7 @@ hunter_config(Libcxxabi VERSION 3.6.2) # Clang
 hunter_config(librtmp VERSION 2.4.0-p0)
 hunter_config(Libssh2 VERSION 1.7.0)
 hunter_config(Lua VERSION 5.3.2)
-hunter_config(MySQL-client VERSION 6.1.9)
+hunter_config(MySQL-client VERSION 6.1.9-p0)
 hunter_config(NASM VERSION 2.12.02)
 hunter_config(OpenBLAS VERSION 0.2.19-p0)
 hunter_config(OpenCL VERSION 2.1-p3)

--- a/cmake/projects/MySQL-client/hunter.cmake
+++ b/cmake/projects/MySQL-client/hunter.cmake
@@ -31,6 +31,17 @@ hunter_add_version(
     3268345d8e324d11380cd26475e1669bc5ff2fa0
 )
 
+hunter_add_version(
+    PACKAGE_NAME
+    MySQL-client
+    VERSION
+    "6.1.9-p0"
+    URL
+    "https://github.com/hunter-packages/mysql-client/archive/v1.6.9-p0.tar.gz"
+    SHA1
+    64c3fb0500e03fc0ee188dca1ec33e52c2f54e32
+)
+
 # https://github.com/ruslo/hunter/issues/705
 # hunter_cacheable(MySQL-client)
 

--- a/examples/MySQL-client/CMakeLists.txt
+++ b/examples/MySQL-client/CMakeLists.txt
@@ -7,7 +7,7 @@ include("../common.cmake")
 project(MySQL-client-example)
 
 hunter_add_package(MySQL-client)
-find_package(MySQL-client REQUIRED)
+find_package(MySQL-client CONFIG REQUIRED)
 
 set(${PROJECT_NAME}_SOURCES
   main.c
@@ -17,5 +17,5 @@ add_executable(${PROJECT_NAME}
     ${${PROJECT_NAME}_SOURCES}
 )
 
-target_link_libraries(${PROJECT_NAME} "MySQL::client")
+target_link_libraries(${PROJECT_NAME} "MySQL::libmysql")
 


### PR DESCRIPTION
As a side effect target name changed from MySQL::client to MySQL::mysqlclient. Will update the wiki after PR accepted.