### PR TITLE
support MSVC 19.11 compiler

### DIFF
--- a/cmake/modules/hunter_setup_msvc.cmake
+++ b/cmake/modules/hunter_setup_msvc.cmake
@@ -41,7 +41,7 @@ macro(hunter_setup_msvc)
     string(COMPARE EQUAL "${MSVC_VERSION}" "1700" _vs_11_2012)
     string(COMPARE EQUAL "${MSVC_VERSION}" "1800" _vs_12_2013)
     string(COMPARE EQUAL "${MSVC_VERSION}" "1900" _vs_14_2015)
-    string(COMPARE EQUAL "${MSVC_VERSION}" "1910" _vs_15_2017)
+    string(REGEX MATCH "^191[01]$" _vs_15_2017 "${MSVC_VERSION}")
 
     if(_vs_8_2005)
       set(HUNTER_MSVC_VERSION "8")


### PR DESCRIPTION
MSVC 15.3 preview 2 compiler version is 19.11 and so was not identified as VS 2017