### PR TITLE
boost: add ability to cross compile boost with mingw from linux to windows

### DIFF
--- a/cmake/projects/Boost/atomic/hunter.cmake
+++ b/cmake/projects/Boost/atomic/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     atomic
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/chrono/hunter.cmake
+++ b/cmake/projects/Boost/chrono/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     chrono
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/context/hunter.cmake
+++ b/cmake/projects/Boost/context/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     context
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/coroutine/hunter.cmake
+++ b/cmake/projects/Boost/coroutine/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     coroutine
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/date_time/hunter.cmake
+++ b/cmake/projects/Boost/date_time/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     date_time
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/exception/hunter.cmake
+++ b/cmake/projects/Boost/exception/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     exception
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/filesystem/hunter.cmake
+++ b/cmake/projects/Boost/filesystem/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     filesystem
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/graph/hunter.cmake
+++ b/cmake/projects/Boost/graph/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/graph_parallel/hunter.cmake
+++ b/cmake/projects/Boost/graph_parallel/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph_parallel
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -256,4 +256,4 @@ hunter_add_version(
 
 hunter_pick_scheme(DEFAULT url_sha1_boost)
 hunter_cacheable(Boost)
-hunter_download(PACKAGE_NAME Boost PACKAGE_INTERNAL_DEPS_ID "14")
+hunter_download(PACKAGE_NAME Boost PACKAGE_INTERNAL_DEPS_ID "15")

--- a/cmake/projects/Boost/hunter.cmake.in
+++ b/cmake/projects/Boost/hunter.cmake.in
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     boost_component
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/iostreams/hunter.cmake
+++ b/cmake/projects/Boost/iostreams/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     iostreams
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/locale/hunter.cmake
+++ b/cmake/projects/Boost/locale/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     locale
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/log/hunter.cmake
+++ b/cmake/projects/Boost/log/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     log
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/math/hunter.cmake
+++ b/cmake/projects/Boost/math/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     math
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/mpi/hunter.cmake
+++ b/cmake/projects/Boost/mpi/hunter.cmake
@@ -26,5 +26,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     mpi
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/program_options/hunter.cmake
+++ b/cmake/projects/Boost/program_options/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     program_options
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/python/hunter.cmake
+++ b/cmake/projects/Boost/python/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     python
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/random/hunter.cmake
+++ b/cmake/projects/Boost/random/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     random
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/regex/hunter.cmake
+++ b/cmake/projects/Boost/regex/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     regex
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/schemes/url_sha1_boost.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost.cmake.in
@@ -94,24 +94,24 @@ else()
   set(env_cmd "")
 endif()
 
-if("@MSVC@")
+if(CMAKE_HOST_WIN32)
   set(install_cmd "b2")
   set(bootstrap_cmd "bootstrap.bat")
-elseif("@MINGW@")
-  # Test scenario: MinGW installed in system, Visual Studio - not
-  set(install_cmd "b2")
-  set(bootstrap_cmd "bootstrap.bat" "gcc")
 else()
   set(install_cmd "./b2")
-  if(APPLE)
-    # Clear Xcode environment
-    set(
-        bootstrap_cmd
-        . "@HUNTER_GLOBAL_SCRIPT_DIR@/clear-all.sh" && ./bootstrap.sh
-    )
-  else()
-    set(bootstrap_cmd "./bootstrap.sh")
-  endif()
+  set(bootstrap_cmd "./bootstrap.sh")
+endif()
+
+if("@MINGW@")
+  # Test scenario: MinGW installed in system, Visual Studio - not
+  list(APPEND bootstrap_cmd "gcc")
+endif()
+if(APPLE)
+  # Clear Xcode environment
+  set(
+      bootstrap_cmd
+      . "@HUNTER_GLOBAL_SCRIPT_DIR@/clear-all.sh" && ${bootstrap_cmd}
+  )
 endif()
 
 if("@MSVC@")

--- a/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
@@ -251,6 +251,10 @@ set(
     "--user-config=${boost_user_jam}"
     --with-@HUNTER_PACKAGE_COMPONENT@
 )
+if("@MINGW@")
+  # cross compile from "linux" to "windows" using mingw
+  set(build_opts target-os=windows ${build_opts})
+endif()
 
 hunter_boost_component_b2_args(
     "@HUNTER_PACKAGE_COMPONENT@"
@@ -337,17 +341,17 @@ if(@HUNTER_STATUS_DEBUG@)
   set(verbose_output "-d+2 --debug-configuration")
 endif()
 
-if("@MSVC@")
+if(CMAKE_HOST_WIN32)
   set(bootstrap_cmd "bootstrap.bat")
-  set(b2_cmd "b2")
-elseif("@MINGW@")
-  set(bootstrap_cmd "bootstrap.bat" "gcc")
   set(b2_cmd "b2")
 else()
   set(bootstrap_cmd "./bootstrap.sh")
   set(b2_cmd "./b2")
 endif()
 
+if("@MINGW@")
+  list(APPEND bootstrap_cmd "gcc")
+endif()
 
 if(HUNTER_STATUS_DEBUG)
   file(READ "${boost_user_jam}" USER_JAM_CONTENT)

--- a/cmake/projects/Boost/serialization/hunter.cmake
+++ b/cmake/projects/Boost/serialization/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     serialization
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/signals/hunter.cmake
+++ b/cmake/projects/Boost/signals/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     signals
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/system/hunter.cmake
+++ b/cmake/projects/Boost/system/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     system
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/test/hunter.cmake
+++ b/cmake/projects/Boost/test/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     test
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/thread/hunter.cmake
+++ b/cmake/projects/Boost/thread/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     thread
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/timer/hunter.cmake
+++ b/cmake/projects/Boost/timer/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     timer
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )

--- a/cmake/projects/Boost/wave/hunter.cmake
+++ b/cmake/projects/Boost/wave/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     wave
-    PACKAGE_INTERNAL_DEPS_ID "14"
+    PACKAGE_INTERNAL_DEPS_ID "15"
 )


### PR DESCRIPTION
- on mingw (when cross compiling mode) assume cross compilation from linux to windows

tested on Ubuntu 16.04
```
sudo apt-get install mingw-w64 g++-mingw-w64
cd examples/Boost-filesystem
cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE=~/path/to/toolchain/Toolchain-Ubuntu-mingw64.cmake
```

contents of `Toolchain-Ubuntu-mingw64.cmake`
```
# Sample toolchain file for building for Windows from an Ubuntu Linux system.
#
# Typical usage:
#    *) install cross compiler: `sudo apt-get install mingw-w64 g++-mingw-w64`
#    *) cd build
#    *) cmake -DCMAKE_TOOLCHAIN_FILE=~/Toolchain-Ubuntu-mingw64.cmake ..

set(CMAKE_SYSTEM_NAME Windows)
set(TOOLCHAIN_PREFIX x86_64-w64-mingw32)

# cross compilers to use for C and C++
set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
set(CMAKE_Fortran_COMPILER ${TOOLCHAIN_PREFIX}-gfortran)
set(CMAKE_RC_COMPILER ${TOOLCHAIN_PREFIX}-windres)

# target environment on the build host system
#   set 1st to dir with the cross compiler's C/C++ headers/libs
set(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})

# modify default behavior of FIND_XXX() commands to
# search for headers/libs in the target environment and
# search for programs in the build host environment
set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
```