### PR TITLE
Boost building conflicts on gentoo

### DIFF
--- a/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
@@ -400,6 +400,7 @@ ExternalProject_Add(
     ${b2_cmd}
     ${verbose_output}
     ${build_opts}
+    --ignore-site-config # Ignore Gentoo specific optimization "none" in site config that only the patched bjam of Gentoo can understand.
     BUILD_IN_SOURCE
     1
     INSTALL_COMMAND
@@ -408,6 +409,7 @@ ExternalProject_Add(
     ${build_opts}
     stage # install only libraries, headers installed in `url_sha1_boost`
     "--stagedir=@HUNTER_PACKAGE_INSTALL_PREFIX@"
+    --ignore-site-config # Ignore Gentoo specific optimization "none" in site config that only the patched bjam of Gentoo can understand.
     ${log_opts}
 )
 


### PR DESCRIPTION
On Gentoo systems with their own boost-build installed
(dev-util/boost-build), trying to build hunter generates an error,
solvable by issuing ./b2 --ignore-site-config
This patch adds the flag to
cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in

Signed-off-by: Carlos Augusto <silvaesilva@gmail.com>