### PR TITLE
Update gflags package to latest unforked release

### DIFF
--- a/examples/gflags/foo.cpp
+++ b/examples/gflags/foo.cpp
@@ -4,5 +4,7 @@ DEFINE_bool(big_menu, true, "Include 'advanced' options in the menu listing");
 DEFINE_string(languages, "english,french,german",
              "comma-separated list of languages to offer in the 'lang' menu");
 
-int main() {
+int main(int argc, char* argv[]) {
+    gflags::ParseCommandLineFlags(&argc, &argv, true);
+    return 0;
 }


### PR DESCRIPTION
Gflags just released version 2.2.1 which should allow Hunter to pull
from the upstream repo instead of the forked version.

Also update the gflags example app to init the gflags library.