### PR TITLE
ceres: add OpenMP to example, needed by MinGW

### DIFF
--- a/examples/ceres-solver-suitesparse/CMakeLists.txt
+++ b/examples/ceres-solver-suitesparse/CMakeLists.txt
@@ -19,6 +19,12 @@ enable_language(Fortran)
 #  CMAKE_ARGS BUILD_SHARED_LIBS=ON
 #)
 
+# need OpenMP for successful linking with mingw
+if(MINGW)
+	find_package(OpenMP REQUIRED)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+endif()
+
 hunter_add_package(ceres-solver)
 
 find_package(Ceres CONFIG REQUIRED)


### PR DESCRIPTION
MinGW-w64 cross compiling needs OpenMP to successfully link the example `ceres-solver-suitesparse`. `g++` links fine without.

I don't know if it is better to just update the examples to search for OpenMP when compiling with mingw, or update the `ceres-solver` cmake config file to instruct it to always search for OpenMP (if ceres was built with OpenMP)