### PR TITLE
Added Live555 package

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -77,6 +77,7 @@ hunter_config(Libcxx VERSION 3.6.2) # Clang
 hunter_config(Libcxxabi VERSION 3.6.2) # Clang
 hunter_config(librtmp VERSION 2.4.0-p0)
 hunter_config(Libssh2 VERSION 1.7.0)
+hunter_config(Live555 VERSION 2017.07.18)
 hunter_config(Lua VERSION 5.3.2)
 hunter_config(MySQL-client VERSION 6.1.9)
 hunter_config(NASM VERSION 2.12.02)

--- a/cmake/find/FindLive555.cmake
+++ b/cmake/find/FindLive555.cmake
@@ -1,0 +1,223 @@
+# FindLive555
+#
+# Find the Live555 Streaming Media Libraries.
+#
+#=============================================================================
+# Copyright 2006-2009 Kitware, Inc.
+# Copyright 2009-2011 Mathieu Malaterre <mathieu.malaterre@gmail.com>
+# Copyright 2015 Alexander Lamaison <alexander.lamaison@gmail.com>
+# Copyright 2017 Ernesto Varoli <ernesto.varoli@gmail.com>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+if(HUNTER_STATUS_DEBUG)
+  message("[hunter] Custom FindLive555 module")
+endif()
+
+# Support preference of static libs by adjusting CMAKE_FIND_LIBRARY_SUFFIXES
+if(LIVE555_USE_STATIC_LIBS)
+  set(_live555_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  if(WIN32)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .lib .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  else()
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a )
+  endif()
+endif()
+
+find_path(LIVE555_GROUPSOCK_INCLUDE_DIR
+  NAMES
+    Groupsock.hh
+  HINTS
+    "${LIVE555_ROOT}"
+  PATH_SUFFIXES
+    groupsock
+)
+
+find_path(LIVE555_LIVEMEDIA_INCLUDE_DIR
+  NAMES
+    liveMedia.hh
+  HINTS
+    "${LIVE555_ROOT}"
+  PATH_SUFFIXES
+    liveMedia
+)
+
+find_path(LIVE555_USAGEENVIRONMENT_INCLUDE_DIR
+  NAMES
+    UsageEnvironment.hh
+  HINTS
+    "${LIVE555_ROOT}"
+  PATH_SUFFIXES
+    UsageEnvironment
+)
+
+find_path(LIVE555_BASICUSAGEENVIRONMENT_INCLUDE_DIR
+  NAMES
+    BasicUsageEnvironment.hh
+  HINTS
+    "${LIVE555_ROOT}"
+  PATH_SUFFIXES
+    BasicUsageEnvironment
+)
+
+if(WIN32 AND NOT CYGWIN)
+  # TODO
+else()
+
+  find_library(LIVE555_BASICUSAGEENVIRONMENT_LIBRARY
+    NAMES
+      BasicUsageEnvironment
+    HINTS
+      "${LIVE555_ROOT}"
+    PATH_SUFFIXES
+      lib
+  )
+
+  find_library(LIVE555_USAGEENVIRONMENT_LIBRARY
+    NAMES
+      UsageEnvironment
+    HINTS
+      "${LIVE555_ROOT}"
+    PATH_SUFFIXES
+      lib
+  )
+
+  find_library(LIVE555_GROUPSOCK_LIBRARY
+    NAMES
+      groupsock
+    HINTS
+      "${LIVE555_ROOT}"
+    PATH_SUFFIXES
+      lib
+  )
+
+  find_library(LIVE555_LIVEMEDIA_LIBRARY
+    NAMES
+      liveMedia
+    HINTS
+      "${LIVE555_ROOT}"
+    PATH_SUFFIXES
+      lib
+  )
+
+  mark_as_advanced(LIVE555_BASICUSAGEENVIRONMENT_LIBRARY LIVE555_USAGEENVIRONMENT_LIBRARY LIVE555_GROUPSOCK_LIBRARY LIVE555_LIVEMEDIA_LIBRARY)
+
+  # compat defines
+  set(LIVE555_BASICUSAGEENVIRONMENT_LIBRARIES ${LIVE555_BASICUSAGEENVIRONMENT_LIBRARY} ${CMAKE_DL_LIBS})
+  set(LIVE555_USAGEENVIRONMENT_LIBRARIES ${LIVE555_USAGEENVIRONMENT_LIBRARY} ${CMAKE_DL_LIBS})
+  set(LIVE555_LIVEMEDIA_LIBRARIES ${LIVE555_LIVEMEDIA_LIBRARY} ${CMAKE_DL_LIBS})
+  set(LIVE555_GROUPSOCK_LIBRARIES ${LIVE555_GROUPSOCK_LIBRARY} ${CMAKE_DL_LIBS})
+
+  set(LIVE555_LIBRARIES ${LIVE555_LIVEMEDIA_LIBRARY} ${LIVE555_GROUPSOCK_LIBRARY} ${LIVE555_USAGEENVIRONMENT_LIBRARY} ${LIVE555_BASICUSAGEENVIRONMENT_LIBRARY} ${CMAKE_DL_LIBS})
+
+endif()
+
+function(getLiveVersion library_name library_version_ret)
+  string(TOUPPER ${library_name} uc_library_name)
+  set(library_version_define "${uc_library_name}_LIBRARY_VERSION_INT")
+  set(library_include_dir "${LIVE555_${uc_library_name}_INCLUDE_DIR}")
+
+  if(EXISTS "${library_include_dir}/${library_name}_version.hh")
+    file(STRINGS "${library_include_dir}/${library_name}_version.hh" library_version_str
+      REGEX "^#[\t ]*define[\t ]+${library_version_define}[\t ]+([0-9])+.*")
+    string(COMPARE EQUAL "${library_version_str}" "" _is_empty)
+    if(_is_empty)
+      message(
+          FATAL_ERROR
+          "Incorrect ${library_version_define} define in header"
+          ": ${library_include_dir}/${library_name}_version.hh"
+      )
+    endif()
+
+    string(REGEX REPLACE "^.*${library_version_define}[\t ]+([0-9]+).*$"
+      "\\1" library_version "${library_version_str}" )
+    set(${library_version_ret} ${library_version} PARENT_SCOPE)
+  endif()
+
+endfunction()
+
+getLiveVersion("liveMedia" LIVEMEDIA_VERSION)
+getLiveVersion("BasicUsageEnvironment" BASICUSAGEENVIRONMENT_VERSION)
+getLiveVersion("UsageEnvironment" USAGEENVIRONMENT_VERSION)
+getLiveVersion("groupsock" GROUPSOCK_VERSION)
+
+include(FindPackageHandleStandardArgs)
+
+if( NOT (LIVEMEDIA_VERSION EQUAL GROUPSOCK_VERSION AND BASICUSAGEENVIRONMENT_VERSION EQUAL USAGEENVIRONMENT_VERSION AND USAGEENVIRONMENT_VERSION EQUAL LIVEMEDIA_VERSION))
+  message(
+          FATAL_ERROR
+          "Incorrect libraries versions:
+          \tliveMedia: ${LIVEMEDIA_VERSION}
+          \tBasicUsageEnvironment: ${BASICUSAGEENVIRONMENT_VERSION}
+          \tUsageEnvironment: ${USAGEENVIRONMENT_VERSION}
+          \tgroupsock ${GROUPSOCK_VERSION}"
+      )
+else()
+  set(LIVE555_VERSION ${LIVEMEDIA_VERSION})
+endif()
+
+if (LIVE555_VERSION)
+  find_package_handle_standard_args(Live555
+    REQUIRED_VARS
+      LIVE555_LIBRARIES
+      LIVE555_LIVEMEDIA_INCLUDE_DIR
+      LIVE555_GROUPSOCK_INCLUDE_DIR
+      LIVE555_USAGEENVIRONMENT_INCLUDE_DIR
+      LIVE555_BASICUSAGEENVIRONMENT_INCLUDE_DIR
+    VERSION_VAR
+      LIVE555_VERSION
+    FAIL_MESSAGE
+      "Could NOT find Live555 Streaming Media, try to set the path to Live555 root folder in the system variable LIVE555_ROOT_DIR"
+  )
+else ()
+  find_package_handle_standard_args(Live555 "Could NOT find Live555 Streaming Media, try to set the path to Live555 root folder in the system variable LIVE_ROOT_DIR"
+    LIVE555_LIBRARIES
+    LIVE555_LIVEMEDIA_INCLUDE_DIR
+    LIVE555_GROUPSOCK_INCLUDE_DIR
+    LIVE555_USAGEENVIRONMENT_INCLUDE_DIR
+    LIVE555_BASICUSAGEENVIRONMENT_INCLUDE_DIR
+  )
+endif ()
+
+mark_as_advanced(LIVE555_LIVEMEDIA_INCLUDE_DIR
+                 LIVE555_GROUPSOCK_INCLUDE_DIR
+                 LIVE555_USAGEENVIRONMENT_INCLUDE_DIR
+                 LIVE555_BASICUSAGEENVIRONMENT_INCLUDE_DIR
+                 LIVE555_LIBRARIES)
+
+function(addLiveLibrary library_name)
+  string(TOUPPER ${library_name} uc_library_name)
+  if(NOT TARGET Live555::${library_name} AND 
+     EXISTS "${LIVE555_${uc_library_name}_LIBRARY}")
+    add_library(Live555::${library_name} UNKNOWN IMPORTED)
+    set_target_properties(Live555::${library_name} PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${LIVE555_${uc_library_name}_INCLUDE_DIR}")
+    set_target_properties(Live555::${library_name} PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${CMAKE_DL_LIBS}")
+    if(EXISTS "${LIVE555_${uc_library_name}_LIBRARY}")
+      set_target_properties(Live555::${library_name} PROPERTIES
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C++"
+        IMPORTED_LOCATION "${LIVE555_${uc_library_name}_LIBRARY}")
+    endif()
+  endif()
+endfunction()
+
+if(LIVE555_FOUND)
+  addLiveLibrary("LiveMedia")
+  addLiveLibrary("Groupsock")
+  addLiveLibrary("UsageEnvironment")
+  addLiveLibrary("BasicUsageEnvironment")
+endif()
+
+# Restore the original find library ordering
+if(LIVE555_USE_STATIC_LIBS)
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${_live555_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+endif()

--- a/cmake/projects/Live555/hunter.cmake
+++ b/cmake/projects/Live555/hunter.cmake
@@ -1,0 +1,49 @@
+# !!! DO NOT PLACE HEADER GUARDS HERE !!!
+
+# Load used modules
+include(hunter_add_version)
+include(hunter_configuration_types)
+include(hunter_download)
+include(hunter_pick_scheme)
+include(hunter_cacheable)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Live555
+    VERSION
+    "2017.07.18"
+    URL
+    "https://download.videolan.org/pub/contrib/live555/live.2017.07.18.tar.gz"
+    SHA1
+    01558c54c7d6790e004a1dc021890a54eeaa639e
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Live555
+    VERSION
+    "2016.11.28"
+    URL
+    "https://wx3sweden.se/live555-archive/live.2016.11.28.tar.gz"
+    SHA1
+    6df30a0c20c973e4f7f0dd1030a863fb6329cd7a
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Live555
+    VERSION
+    "2014.10.07"
+    URL
+    "https://wx3sweden.se/live555-archive/liblivemedia-dmo_2014.10.07.tar.gz"
+    SHA1
+    d6d1919b78366efd366b1bfa1c27fddd1f060f3c
+)
+
+hunter_pick_scheme(DEFAULT url_sha1_live555)
+
+hunter_cacheable(Live555)
+hunter_download(
+    PACKAGE_NAME Live555
+    #PACKAGE_INTERNAL_DEPS_ID "1"
+)

--- a/cmake/projects/Live555/schemes/url_sha1_live555.cmake.in
+++ b/cmake/projects/Live555/schemes/url_sha1_live555.cmake.in
@@ -1,0 +1,83 @@
+# Copyright (c) 2013, 2017 Ruslan Baratov, Ernesto Varoli
+# All rights reserved.
+
+cmake_minimum_required(VERSION 3.0)
+project(Hunter)
+
+include(ExternalProject) # ExternalProject_Add
+
+# Scheme for download and install Live555 Streaming Media
+
+list(APPEND CMAKE_MODULE_PATH "@HUNTER_SELF@/cmake/modules")
+
+include(hunter_dump_cmake_flags)
+include(hunter_status_debug)
+include(hunter_test_string_not_empty)
+include(hunter_user_error)
+
+hunter_status_debug("Scheme: url_sha1_live555")
+
+# Check preconditions
+hunter_test_string_not_empty("@HUNTER_SELF@")
+hunter_test_string_not_empty("@HUNTER_EP_NAME@")
+hunter_test_string_not_empty("@HUNTER_PACKAGE_URL@")
+hunter_test_string_not_empty("@HUNTER_PACKAGE_SHA1@")
+hunter_test_string_not_empty("@HUNTER_PACKAGE_DOWNLOAD_DIR@")
+hunter_test_string_not_empty("@HUNTER_PACKAGE_SOURCE_DIR@")
+hunter_test_string_not_empty("@HUNTER_PACKAGE_INSTALL_PREFIX@")
+hunter_test_string_not_empty("@HUNTER_PACKAGE_LICENSE_DIR@")
+hunter_test_string_not_empty("@HUNTER_GLOBAL_SCRIPT_DIR@")
+
+set(configure_command "./genMakefiles")
+
+hunter_dump_cmake_flags(SKIP_INCLUDES)
+# -> CMAKE_CXX_FLAGS
+# -> CMAKE_C_FLAGS
+
+set(
+    configure_command
+    . "@HUNTER_GLOBAL_SCRIPT_DIR@/clear-all.sh" && "${configure_command}"
+)
+set(build_command . "@HUNTER_GLOBAL_SCRIPT_DIR@/clear-all.sh" && make)
+
+#if (BUILD_SHARED_LIBS)
+#  set(shared_flag shared)
+#else()
+#  set(shared_flag no-shared)
+#endif()
+
+#set(configure_opts ${configure_opts} threads ${shared_flag})
+set(configure_opts linux-64bit)
+
+ExternalProject_Add(
+    "@HUNTER_EP_NAME@"
+    URL
+    @HUNTER_PACKAGE_URL@
+    URL_HASH
+    SHA1=@HUNTER_PACKAGE_SHA1@
+    DOWNLOAD_DIR
+    "@HUNTER_PACKAGE_DOWNLOAD_DIR@"
+    SOURCE_DIR
+    "@HUNTER_PACKAGE_SOURCE_DIR@"
+    INSTALL_DIR
+    "@HUNTER_PACKAGE_INSTALL_PREFIX@"
+        # not used, just avoid creating Install/<name> empty directory
+    CONFIGURE_COMMAND
+    ${configure_command}
+    ${configure_opts}
+    BUILD_COMMAND
+    ${build_command}
+    BUILD_IN_SOURCE
+    1
+    INSTALL_COMMAND
+    "make" "install" "DESTDIR=@HUNTER_PACKAGE_INSTALL_PREFIX@" "PREFIX="
+    # Install without documentation
+    # * https://github.com/openssl/openssl/issues/57
+    #COMMAND # Copy license files
+    #"@CMAKE_COMMAND@"
+    #"-C@HUNTER_ARGS_FILE@" # for 'HUNTER_INSTALL_LICENSE_FILES'
+    #"-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
+    #"-Ddstdir=@HUNTER_PACKAGE_LICENSE_DIR@"
+    #-P
+    #"@HUNTER_SELF@/scripts/try-copy-license.cmake"
+)

--- a/examples/Live555/CMakeLists.txt
+++ b/examples/Live555/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (c) 2015-2017, Ruslan Baratov Ernesto Varoli
+# All rights reserved.
+
+cmake_minimum_required(VERSION 3.0)
+
+# Emulate HunterGate:
+# * https://github.com/hunter-packages/gate
+include("../common.cmake")
+
+project(download-Live555)
+
+hunter_add_package(Live555)
+
+find_package(Live555 REQUIRED)
+
+add_executable(foo foo.cpp)
+target_link_libraries(foo Live555::LiveMedia)
+target_link_libraries(foo Live555::Groupsock)
+target_link_libraries(foo Live555::UsageEnvironment)
+target_link_libraries(foo Live555::BasicUsageEnvironment)
+
+

--- a/examples/Live555/foo.cpp
+++ b/examples/Live555/foo.cpp
@@ -1,0 +1,9 @@
+#include "liveMedia.hh"
+#include "GroupsockHelper.hh"
+#include "BasicUsageEnvironment.hh"
+#include "UsageEnvironment.hh"
+
+int main() {
+
+  return 0;
+}


### PR DESCRIPTION
As requested by @roalz in #911 I added Live555 to hunter.
The main issue is the release policy: the original author remove old version from the server, "latest" is the only version available. I used videolan repository for newer version and [wx3sweden.se](https://wx3sweden.se/live555-archive/) for early ones. I only added three version, since there are A LOT of releases. The choice was made because of my needs, I can add new versions if asked.