### PR TITLE
Add cotire package

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -49,6 +49,7 @@ hunter_config(CURL VERSION 7.49.1-DEV-v5)
 hunter_config(Clang VERSION 3.6.2-p0)
 hunter_config(ClangToolsExtra VERSION 3.6.2) # Clang
 hunter_config(Comet VERSION 4.0.2)
+hunter_config(cotire VERSION 1.7.10)
 hunter_config(CppNetlib VERSION 0.10.1-hunter-3)
 hunter_config(CppNetlibUri VERSION 1.0.4-hunter)
 hunter_config(CsvParserCPlusPlus VERSION 1.0.1)

--- a/cmake/projects/cotire/hunter.cmake
+++ b/cmake/projects/cotire/hunter.cmake
@@ -1,0 +1,22 @@
+# Copyright (c) 2017, Pawel Bylica
+# All rights reserved.
+
+# !!! DO NOT PLACE HEADER GUARDS HERE !!!
+
+include(hunter_add_version)
+include(hunter_download)
+include(hunter_pick_scheme)
+
+hunter_add_version(
+    PACKAGE_NAME
+    cotire
+    VERSION
+    "1.7.10"
+    URL
+    "https://github.com/sakra/cotire/releases/download/cotire-1.7.10/cotire.cmake"
+    SHA1
+    bda78a4ee0fd5e7b17d5c25259a65d9770bdb9f5
+)
+
+hunter_pick_scheme(DEFAULT url_sha1_download)
+hunter_download(PACKAGE_NAME cotire)

--- a/examples/cotire/CMakeLists.txt
+++ b/examples/cotire/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) 2017, Pawel Bylica
+# All rights reserved.
+
+cmake_minimum_required(VERSION 3.0)
+
+# Emulate HunterGate:
+# * https://github.com/hunter-packages/gate
+include("../common.cmake")
+
+project(download-cotire)
+
+# download cotire
+hunter_add_package(cotire)
+message(${COTIRE_ROOT})
+
+# This works, but is quite ugly. Can we get include(cotire) to work?
+include(${COTIRE_ROOT}/cotire.cmake)


### PR DESCRIPTION
I'd like to add cotire CMake module as a Hunter package. Their releases consist of unpacked cotire.cmake module only. Using `url_sha1_download` works ok, but I'd like to file to be move to any common path for CMake modules, e.g. `Install/cmake`.