### PR TITLE
fix pack_git_submodule with subdir

### DIFF
--- a/cmake/modules/hunter_pack_git_submodule.cmake
+++ b/cmake/modules/hunter_pack_git_submodule.cmake
@@ -201,13 +201,13 @@ function(hunter_pack_git_submodule)
     set(source_flag)
   else()
     hunter_status_debug("SUBMODULE_SOURCE_SUBDIR specified, only archive subfolder: ${x_SUBMODULE_SOURCE_SUBDIR}")
-    set(source_flag ":${x_SUBMODULE_SOURCE_SUBDIR}")
+    set(source_flag "/${x_SUBMODULE_SOURCE_SUBDIR}")
   endif()
 
-  set(cmd "${GIT_EXECUTABLE}" archive HEAD${source_flag} -o "${archive}")
+  set(cmd "${GIT_EXECUTABLE}" archive HEAD -o "${archive}")
   execute_process(
       COMMAND ${cmd}
-      WORKING_DIRECTORY "${submodule_dir}"
+      WORKING_DIRECTORY "${submodule_dir}${source_flag}"
       RESULT_VARIABLE result
       OUTPUT_VARIABLE output
       ERROR_VARIABLE error


### PR DESCRIPTION
- `git archive HEAD:subdir -o archive.tar.gz` creates a different
  archive (different SHA1) each time
- calling `git archive HEAD -o archive.tar.gz` with the right working
  directory produces the same archive (same SHA1) each time