### PR TITLE
added SocketIOClient package

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -108,6 +108,7 @@ hunter_config(SDL2 VERSION 2.0.4-p4)
 hunter_config(SDL_mixer VERSION 2.0.1-p1)
 hunter_config(SQLite3 VERSION autoconf-3080803) #R-Tree enabled
 hunter_config(Sober VERSION 0.1.3)
+hunter_config(SocketIOClient VERSION 1.6.1)
 hunter_config(Sugar VERSION 1.2.2)
 hunter_config(SuiteSparse VERSION 4.5.1-p0)
 hunter_config(TIFF VERSION 4.0.2-p3)

--- a/cmake/projects/SocketIOClient/hunter.cmake
+++ b/cmake/projects/SocketIOClient/hunter.cmake
@@ -1,0 +1,25 @@
+# Copyright (c) 2013-2017, Ruslan Baratov, Richard Hodges
+# All rights reserved.
+
+# !!! DO NOT PLACE HEADER GUARDS HERE !!!
+
+include(hunter_add_version)
+include(hunter_cacheable)
+include(hunter_cmake_args)
+include(hunter_download)
+include(hunter_pick_scheme)
+
+hunter_add_version(
+        PACKAGE_NAME
+        SocketIOClient
+        VERSION
+        "1.6.1"
+        URL
+        "https://github.com/madmongo1/socket.io-client-cpp/archive/v1.6.1-hunter-1.tar.gz"
+        SHA1
+        3e67677d8d0328c07c7a2d2c9e8ebda87c9ad583
+)
+
+hunter_pick_scheme(DEFAULT url_sha1_cmake)
+hunter_cacheable(SocketIOClient)
+hunter_download(PACKAGE_NAME SocketIOClient)


### PR DESCRIPTION
Adds support for hunterized SocketIOClient package. Note that there is a known problem with the socketio code when building against openssl 1.1. 

This package needs to bee built against openssl 1.0....

I will fix the socketio problem in due course
