### PR TITLE
updated .gitignore to prevent inclusion of JetBrains CLion artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ _Base
 # emacs junk
 *.*~
 *~
+
+# Clion
+.idea/
+


### PR DESCRIPTION
When opening a project in CLion, a hidden directory is created called .idea/

Some of this is useful to keep if you're compiling but for the hunter project it's just noise.

I have updated .gitignore to ignore this directory.
