### PR TITLE
ceres-solver: add example dynamic LAPACK

### DIFF
--- a/examples/ceres-solver-suitesparse-dynLAPACK/CMakeLists.txt
+++ b/examples/ceres-solver-suitesparse-dynLAPACK/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright (c) 2015, Ruslan Baratov
+# All rights reserved.
+
+cmake_minimum_required(VERSION 3.0)
+
+set(TESTING_CONFIG_OPT FILEPATH "${CMAKE_CURRENT_LIST_DIR}/config.cmake")
+
+# Emulate HunterGate:
+# * https://github.com/hunter-packages/gate
+include("../common.cmake")
+
+project(download-ceres-solver)
+# build LAPACK as shared library
+#hunter_config(LAPACK
+#  VERSION ${HUNTER_LAPACK_VERSION}
+#  CMAKE_ARGS BUILD_SHARED_LIBS=ON
+#)
+# as alternative build LAPACK as static lib by removing the above lines from config.cmake
+# If doing so you need to enable Fortran support
+# enable_language(Fortran)
+# build LAPACK as shared library
+
+hunter_add_package(ceres-solver)
+
+find_package(Ceres CONFIG REQUIRED)
+
+add_executable(foo foo.cpp)
+target_link_libraries(foo ceres)
+

--- a/examples/ceres-solver-suitesparse-dynLAPACK/config.cmake
+++ b/examples/ceres-solver-suitesparse-dynLAPACK/config.cmake
@@ -1,0 +1,9 @@
+hunter_config(ceres-solver
+  VERSION ${HUNTER_ceres-solver_VERSION} CMAKE_ARGS
+    LAPACK=ON
+    SUITESPARSE=ON
+)
+hunter_config(LAPACK
+  VERSION ${HUNTER_LAPACK_VERSION}
+  CMAKE_ARGS BUILD_SHARED_LIBS=ON
+)

--- a/examples/ceres-solver-suitesparse-dynLAPACK/foo.cpp
+++ b/examples/ceres-solver-suitesparse-dynLAPACK/foo.cpp
@@ -1,0 +1,43 @@
+#include <ceres/ceres.h>
+#include <ceres/rotation.h>
+
+using ceres::AutoDiffCostFunction;
+using ceres::CostFunction;
+using ceres::Problem;
+using ceres::Solver;
+using ceres::Solve;
+
+struct ModelConst
+{
+	// Calculate the residuals,
+	// the input parameters are the ones optimized for
+	template <typename T>
+	bool operator()(const T* const x,
+					T* residual) const {
+		residual[0] = T(42) - x[0];
+		return true;
+	}
+};
+int main(int argc, char* argv[]) {
+  Problem problem;
+  // variable to optimize in place
+  double x = 0;
+  Solver::Options options;
+  Solver::Summary summary;
+
+  // use a sparse solver explicitly
+  options.linear_solver_type = ceres::SPARSE_NORMAL_CHOLESKY;
+
+  // print minimizer output  
+  options.minimizer_progress_to_stdout = true;
+
+  // AutoDiffCostFunction<Model_to_use, numberOfResiduals, [dimOfParameter]+>
+  CostFunction* cost_fun
+      = new AutoDiffCostFunction<ModelConst, 1, 1>(
+        new ModelConst());
+  problem.AddResidualBlock(cost_fun, NULL, &x);
+  Solve(options, &problem, &summary);
+
+  // output optimized result
+  std::cout << "x: " << x << std::endl;
+}


### PR DESCRIPTION
this PR adds an example testing ceres-solver built with SuiteSparse using a dynamic LAPACK lib. I'm using this configuration in all my projects. It would be nice that this configuration is tested and maybe even cached

should we maybe merge the ceres-tests into one testing branch `pkg.ceres-solver` instead of the two we have now?