### PR TITLE
LAPACK: add prebuilt dll for MSVC

### DIFF
--- a/cmake/projects/LAPACK/hunter-msvc.cmake
+++ b/cmake/projects/LAPACK/hunter-msvc.cmake
@@ -1,0 +1,36 @@
+# Copyright (c) 2017, NeroBurner
+# All rights reserved.
+
+include(hunter_report_broken_package)
+
+#hunter_cacheable(LAPACK) # install is always cacheable
+
+# determine architecture
+include(hunter_check_toolchain_definition)
+hunter_check_toolchain_definition(NAME "_WIN64"    DEFINED _WIN64_defined)
+
+if(_WIN64_defined)
+  hunter_add_version(
+    PACKAGE_NAME
+    LAPACK
+    VERSION
+    "3.7.1"
+    URL
+    https://github.com/hunter-packages/lapack/releases/download/v3.7.1-p0/lapack-prebuilt-3.7.1-msvc-amd64.zip
+    SHA1
+    4a6e51690e36747d51e4334358abac99ca22378c
+  )
+else()
+  hunter_report_broken_package("LAPACK on MSVC is only available on WIN64")
+endif()
+
+# pass cmake arguments
+hunter_cmake_args(
+    LAPACK
+    CMAKE_ARGS
+    HUNTER_INSTALL_LICENSE_FILES=LICENSE
+)
+
+# Pick a download scheme
+hunter_pick_scheme(DEFAULT url_sha1_unpack_install)
+

--- a/cmake/projects/LAPACK/hunter-source.cmake
+++ b/cmake/projects/LAPACK/hunter-source.cmake
@@ -1,0 +1,27 @@
+# Copyright (c) 2017, NeroBurner
+# All rights reserved.
+
+hunter_cacheable(LAPACK)
+
+# List of versions here...
+hunter_add_version(
+    PACKAGE_NAME
+    LAPACK
+    VERSION
+    "3.7.1"
+    URL
+    https://github.com/hunter-packages/lapack/archive/v3.7.1-p0.tar.gz
+    SHA1
+    82616c0878fbe42f22ece5fadfb38e09456ba5b5
+)
+
+# pass cmake arguments
+hunter_cmake_args(
+    LAPACK
+    CMAKE_ARGS
+    HUNTER_INSTALL_LICENSE_FILES=LICENSE
+)
+
+# Pick a download scheme
+hunter_pick_scheme(DEFAULT url_sha1_cmake)
+

--- a/cmake/projects/LAPACK/hunter.cmake
+++ b/cmake/projects/LAPACK/hunter.cmake
@@ -10,29 +10,11 @@ include(hunter_download)
 include(hunter_pick_scheme)
 include(hunter_cacheable)
 
-hunter_cacheable(LAPACK)
-
-# List of versions here...
-hunter_add_version(
-    PACKAGE_NAME
-    LAPACK
-    VERSION
-    "3.7.1"
-    URL
-    https://github.com/hunter-packages/lapack/archive/v3.7.1-p0.tar.gz
-    SHA1
-    82616c0878fbe42f22ece5fadfb38e09456ba5b5
-)
-
-# pass cmake arguments
-hunter_cmake_args(
-    LAPACK
-    CMAKE_ARGS
-    HUNTER_INSTALL_LICENSE_FILES=LICENSE
-)
-
-# Pick a download scheme
-hunter_pick_scheme(DEFAULT url_sha1_cmake)
+if(NOT MSVC)
+  include("${CMAKE_CURRENT_LIST_DIR}/hunter-source.cmake")
+else()
+  include("${CMAKE_CURRENT_LIST_DIR}/hunter-msvc.cmake")
+endif()
 
 # Download package.
 # Two versions of library will be build:


### PR DESCRIPTION
add lapack 3.7.1 prebuilt for MSVC amd64

This adds a prebuilt dll hosted at https://github.com/NeroBurner/lapack-prebuilt

on MSVC I wasn't able to add a Fortran compiler. But for Unicode support I need to build with MSVC (I wasn't able to make boost::filesystem and MINGW behave).
My solution is to download the prebuilt c-library and provide a cmake-config file when LAPACK is requested when using MSVC

currently I only provide amd64 architecture