### PR TITLE
docs: libuv: fix spelling errors

### DIFF
--- a/docs/packages/pkg/libuv.rst
+++ b/docs/packages/pkg/libuv.rst
@@ -22,8 +22,8 @@ libuv
     find_package(libuv CONFIG REQUIRED)
     target_link_libraries(... libuv::uv)
 
-uv_ssize_t
-~~~~~~~~~~
+``uv_ssize_t``
+~~~~~~~~~~~~~~
 
 Since libuv 1.14.0-p1 type ``uv_ssize_t`` should be used in API instead of
 ``ssize_t``. This is not a part of official ``1.x`` API but will be the part of


### PR DESCRIPTION
- fix spelling errors by making header uv_ssize_t to inline code