### PR TITLE
docs: fix typo 'a priori'

### DIFF
--- a/docs/creating-new/create/cmake.rst
+++ b/docs/creating-new/create/cmake.rst
@@ -381,7 +381,7 @@ Substitute ``unsorted`` with some tag in directive
 
 .. note::
 
-  Since you don't know a priory pull request number leave it as ``N`` for now.
+  Since you don't know the pull request number a priori leave it as ``N`` for now.
   You can update it later.
 
 To check documentation building locally you can run:

--- a/docs/spelling.txt
+++ b/docs/spelling.txt
@@ -42,6 +42,7 @@ performant
 plugin
 plugins
 prebuilt
+priori
 reconstructible
 reproducibility
 runtime


### PR DESCRIPTION
https://en.wikipedia.org/wiki/A_priori_and_a_posteriori