### PR TITLE
Bump PocoCpp to 1.7.9

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -102,7 +102,7 @@ else()
   hunter_config(OpenSSL VERSION 1.1.0f)
 endif()
 hunter_config(PNG VERSION 1.6.26-p1)
-hunter_config(PocoCpp VERSION 1.7.8-p0)
+hunter_config(PocoCpp VERSION 1.7.9-p0)
 hunter_config(PostgreSQL VERSION 9.6.3)
 hunter_config(Protobuf VERSION 3.0.0-p1)
 

--- a/cmake/projects/PocoCpp/hunter.cmake
+++ b/cmake/projects/PocoCpp/hunter.cmake
@@ -8,6 +8,17 @@ hunter_add_version(
     PACKAGE_NAME
     PocoCpp
     VERSION
+    1.7.9-p0
+    URL
+    "https://github.com/hunter-packages/poco/archive/v1.7.9-p0.zip"
+    SHA1
+    1ad6193edd0dbd67c351af7458b464252baf5bb3
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    PocoCpp
+    VERSION
     1.7.8-p0
     URL
     "https://github.com/hunter-packages/poco/archive/v1.7.8-p0.zip"


### PR DESCRIPTION
Updated hunter-packages: https://github.com/hunter-packages/poco/releases/tag/v1.7.9-p0
Add PocoCpp 1.7.9 and bumped default.