### PR TITLE
Download server

### DIFF
--- a/cmake/modules/hunter_download.cmake
+++ b/cmake/modules/hunter_download.cmake
@@ -5,6 +5,7 @@
 include(CMakeParseArguments) # cmake_parse_arguments
 
 include(hunter_create_args_file)
+include(hunter_download_server_url)
 include(hunter_find_licenses)
 include(hunter_find_stamps)
 include(hunter_internal_error)
@@ -77,9 +78,16 @@ function(hunter_download)
   set(root_name "${root_name}_ROOT") # FOO_ROOT
 
   set(HUNTER_PACKAGE_VERSION "${HUNTER_${h_name}_VERSION}")
-  set(ver "${HUNTER_PACKAGE_VERSION}")
-  set(HUNTER_PACKAGE_URL "${HUNTER_${h_name}_URL}")
   set(HUNTER_PACKAGE_SHA1 "${HUNTER_${h_name}_SHA1}")
+  set(ver "${HUNTER_PACKAGE_VERSION}")
+  # set download URL, either direct download or redirected if HUNTER_DOWNLOAD_SERVER is set
+  hunter_download_server_url(
+    PACKAGE "${HUNTER_PACKAGE_NAME}"
+    VERSION "${HUNTER_PACKAGE_VERSION}"
+    SHA1    "${HUNTER_PACKAGE_SHA1}"
+    URL     "${HUNTER_${h_name}_URL}"
+    OUTPUT  HUNTER_PACKAGE_URL
+  )
   set(
       HUNTER_PACKAGE_CONFIGURATION_TYPES
       "${HUNTER_${h_name}_CONFIGURATION_TYPES}"
@@ -429,6 +437,11 @@ function(hunter_download)
       APPEND
       "${HUNTER_DOWNLOAD_TOOLCHAIN}"
       "set(HUNTER_SUPPRESS_LIST_OF_FILES \"${HUNTER_SUPPRESS_LIST_OF_FILES}\" CACHE INTERNAL \"\")\n"
+  )
+  file(
+      APPEND
+      "${HUNTER_DOWNLOAD_TOOLCHAIN}"
+      "set(HUNTER_DOWNLOAD_SERVER \"${HUNTER_DOWNLOAD_SERVER}\" CACHE INTERNAL \"\")\n"
   )
 
   string(COMPARE NOTEQUAL "${CMAKE_MAKE_PROGRAM}" "" has_make)

--- a/cmake/modules/hunter_download.cmake
+++ b/cmake/modules/hunter_download.cmake
@@ -78,8 +78,8 @@ function(hunter_download)
   set(root_name "${root_name}_ROOT") # FOO_ROOT
 
   set(HUNTER_PACKAGE_VERSION "${HUNTER_${h_name}_VERSION}")
-  set(HUNTER_PACKAGE_SHA1 "${HUNTER_${h_name}_SHA1}")
   set(ver "${HUNTER_PACKAGE_VERSION}")
+  set(HUNTER_PACKAGE_SHA1 "${HUNTER_${h_name}_SHA1}")
   # set download URL, either direct download or redirected if HUNTER_DOWNLOAD_SERVER is set
   hunter_download_server_url(
     PACKAGE "${HUNTER_PACKAGE_NAME}"

--- a/cmake/modules/hunter_download_server_url.cmake
+++ b/cmake/modules/hunter_download_server_url.cmake
@@ -89,7 +89,10 @@ function(hunter_download_server_url)
   # check version to determine if external_project_add can handle multiple download URLs
   set(multiple_urls_allowed TRUE)
   if(CMAKE_VERSION VERSION_LESS 3.7)
-    hunter_status_debug("DOWNLOAD_SERVER: Multiple URLs are not supported, only one URL will be used as download server. Use CMake 3.7+ for multiple URLs (current version: ${CMAKE_VERSION})")
+    set(msg "DOWNLOAD_SERVER: Multiple URLs are not supported,")
+    set(msg "${msg} only one URL will be used as download server.")
+    set(msg "${msg} Use CMake 3.7+ for multiple URLs (current version: ${CMAKE_VERSION})")
+    hunter_status_debug("${msg}")
     set(multiple_urls_allowed FALSE)
   endif()
 

--- a/cmake/modules/hunter_download_server_url.cmake
+++ b/cmake/modules/hunter_download_server_url.cmake
@@ -1,0 +1,123 @@
+# Copyright (c) 2017 NeroBurner
+# All rights reserved.
+
+include(CMakeParseArguments) # cmake_parse_arguments
+
+include(hunter_status_print)
+include(hunter_internal_error)
+include(hunter_test_string_not_empty)
+
+# used gobal variables
+# - HUNTER_DOWNLOAD_SERVER
+#   - if given, a list of servers to download from
+
+# update download url to point to HUNTER_DOWNLOAD_SERVER
+# - PACKAGE:       name of the package to update the url for
+# - VERSION:       version of the package
+# - SHA1:          SHA1 of the package to download, only first 7 digits are used as archive-ID
+# - URL:           original URL for the package
+# - OUTPUT:        variable to output the updated URL
+function(hunter_download_server_url)
+  set(function_name "hunter_download_server_url")
+  set(function_synopsis "${function_name}(PACKAGE foo VERSION 0.1.2-p3 SHA1 somelongsha URL http://original_url.example.com OUTPUT variable)")
+
+  # parse arguments
+  set(one_value_args PACKAGE VERSION SHA1 URL OUTPUT)
+  cmake_parse_arguments(x "" "${one_value_args}" "" ${ARGV})
+
+  # No free arguments allowed
+  list(LENGTH x_UNPARSED_ARGUMENTS x_len)
+  if(NOT x_len EQUAL "0")
+    hunter_internal_error(
+      "'${function_name}' incorrect usage,"
+      " expected no free arguments '${x_UNPARSED_ARGUMENTS}'."
+      " Synopsis: ${function_synopsis}"
+    )
+  endif()
+
+  # check mandatory arguments
+  foreach(arg PACKAGE VERSION SHA1 URL OUTPUT)
+    string(COMPARE EQUAL "${x_${arg}}" "" is_empty)
+    if(is_empty)
+      hunter_internal_error(
+        "'${function_name}' incorrect usage,"
+        " option '${arg}' with one argument is mandatory."
+        " Synopsis: ${function_synopsis}"
+      )
+    endif()
+  endforeach()
+
+  # default to the given URL
+  set(hunter_package_new_url "${x_URL}")
+
+  set(hunter_main_url) # variable for main_url (x_URL if it matches one of the download server)
+  set(hunter_url_list) # list of URLs to try downloading from
+
+  # check if download server is given
+  string(COMPARE NOTEQUAL "${HUNTER_DOWNLOAD_SERVER}" "" use_download_server)
+  if(use_download_server)
+    # update download url to point to HUNTER_DOWNLOAD_SERVER
+
+    # point download URL to DOWNLOAD_SERVER
+    # extract archive-ID from archive SHA1
+    string(SUBSTRING "${x_SHA1}" 0 7 archive_id)
+
+    # get filename from download URL
+    get_filename_component(package_filename_raw "${x_URL}" NAME)
+    # replace special characters from filename
+    string(REGEX REPLACE "[!@#$%^&*?]" "_" package_filename "${package_filename_raw}")
+
+    foreach(list_item ${HUNTER_DOWNLOAD_SERVER})
+      # create new URL
+      set(download_server_url "${list_item}/${x_PACKAGE}/${x_VERSION}/${archive_id}/${package_filename}")
+
+      # check if package URL is in the download server list
+      string(FIND "${x_URL}" "${list_item}" found)
+      if(NOT (found EQUAL -1))
+        # if in list use the original URL instead of name mangling
+        hunter_status_print("DOWNLOAD_SERVER: \"${x_PACKAGE}\": URL \"${x_URL}\" matches list item \"${list_item}\".")
+        set(hunter_main_url "${x_URL}")
+      else()
+        # append URL to list of download URLs
+        list(APPEND hunter_url_list "${download_server_url}")
+      endif()
+    endforeach()
+
+    string(COMPARE NOTEQUAL "${hunter_main_url}" "" has_main_url)
+    if(has_main_url)
+      if(CMAKE_VERSION VERSION_LESS 3.7)
+        # use only original URL
+        set(hunter_package_new_url "${hunter_main_url}")
+      else()
+        # highest priority for original URL
+        set(hunter_package_new_url "${hunter_main_url}" ${hunter_url_list})
+      endif()
+    else()
+      if(CMAKE_VERSION VERSION_LESS 3.7)
+        # use only first server
+        list(GET hunter_url_list 0 hunter_package_new_url)
+      else()
+        # try all download server one after another
+        set(hunter_package_new_url ${hunter_url_list})
+      endif()
+    endif()
+
+    hunter_status_print("DOWNLOAD_SERVER: replacing URL
+    PACKAGE: \"${x_PACKAGE}\"
+    VERSION: \"${x_VERSION}\"
+    SHA1:    \"${x_SHA1}\"
+    old URL: \"${x_URL}\"
+    new URL: \"${hunter_package_new_url}\"")
+
+    set(download_command "./download_package_for_server.sh")
+    set(download_command "${download_command} --PACKAGE \"${x_PACKAGE}\"")
+    set(download_command "${download_command} --VERSION \"${x_VERSION}\" ")
+    set(download_command "${download_command} --SHA1 \"${x_SHA1}\" ")
+    set(download_command "${download_command} --URL \"${x_URL}\"")
+    hunter_status_print("DOWNLOAD_SERVER: download with maintenance-script:
+    ${download_command}")
+  endif()
+
+  # set output_var to found definition
+  set(${x_OUTPUT} ${hunter_package_new_url} PARENT_SCOPE)
+endfunction()

--- a/cmake/modules/hunter_download_server_url.cmake
+++ b/cmake/modules/hunter_download_server_url.cmake
@@ -73,7 +73,7 @@ function(hunter_download_server_url)
 
       # check if package URL is in the download server list
       string(FIND "${x_URL}" "${list_item}" found)
-      if(NOT (found EQUAL -1))
+      if(NOT (found EQUAL "-1"))
         # if in list use the original URL instead of name mangling
         hunter_status_print("DOWNLOAD_SERVER: \"${x_PACKAGE}\": URL \"${x_URL}\" matches list item \"${list_item}\".")
         set(hunter_main_url "${x_URL}")

--- a/cmake/modules/hunter_download_server_url.cmake
+++ b/cmake/modules/hunter_download_server_url.cmake
@@ -88,7 +88,7 @@ function(hunter_download_server_url)
 
   # check version to determine if external_project_add can handle multiple download URLs
   set(multiple_urls_allowed TRUE)
-  if(CMAKE_VERSION VERSION_LESS 3.7)
+  if(CMAKE_VERSION VERSION_LESS "3.7")
     set(msg "DOWNLOAD_SERVER: Multiple URLs are not supported,")
     set(msg "${msg} only one URL will be used as download server.")
     set(msg "${msg} Use CMake 3.7+ for multiple URLs (current version: ${CMAKE_VERSION})")

--- a/docs/quick-start/cmake.rst
+++ b/docs/quick-start/cmake.rst
@@ -37,6 +37,8 @@ Notes about version of CMake
     :doc:`protected sources </user-guides/cmake-user/protected-sources>`
   * ``USERPWD`` sub-option for ``file(DOWNLOAD|UPLOAD ...)`` (`change <https://github.com/Kitware/CMake/commit/e5ba1041be862212a3ad66bd51930fc7beeb8140>`__)
   * ``HTTP_{USERNAME|PASSWORD}`` sub-options for ``ExternalProject_Add`` (`change <https://github.com/Kitware/CMake/commit/e1ca117332fbf6adf3a467a420804e9cb1891582>`__)
+  * List of URLs can be passed to ``ExternalProject_Add``.
+    Used by :ref:`hunter download server`.
 
 * `3.7.1`_ **Minimum for Android projects**
 

--- a/docs/reference/layouts/deployed.rst
+++ b/docs/reference/layouts/deployed.rst
@@ -1,8 +1,13 @@
 .. Copyright (c) 2016-2017, Ruslan Baratov
 .. All rights reserved.
 
+
+.. _layout deployed:
+
 Deployed
 --------
+
+.. _layout deployed common:
 
 Common
 ======
@@ -50,6 +55,8 @@ For example we have file ``toolchain.info`` and we want to save it in
 * Save empty stamp file ``<Toolchain-ID>/DONE``
 
 * Unlock ``<Toolchain-ID>/cmake.lock``
+
+.. _layout deployed base:
 
 Base
 ====
@@ -116,6 +123,8 @@ for development.
   ├── Cellar/                                  # see below
   └── Cache/                                   # see below
 
+.. _layout deployed download:
+
 Download
 ========
 
@@ -147,6 +156,8 @@ Hunter code).
                ├── Build/
                └── Unpacked/             # Unpacked Hunter archive (HUNTER_SELF)
 
+
+.. _layout deployed cache:
 
 Cache
 =====
@@ -201,6 +212,9 @@ arguments, dependencies, etc.).
                                 ├─ deps.info      # list of all dependencies and corresponding SHA1 of cache archive
                                 ├─ CACHE.DONE     # stamp: deps.info and cache.sha1 created and ready to be used
                                 └─ from.server    # info downloaded from server, no need to upload this entry
+
+
+.. _layout deployed cellar:
 
 Cellar
 ======

--- a/docs/reference/user-variables.rst
+++ b/docs/reference/user-variables.rst
@@ -266,7 +266,7 @@ To create new URLs the following template is used:
 
 .. note::
 
-    This is the same structure as Hunter uses for its own :doc:`Download </reference/layouts/deployed>` directory.
+    This is the same structure as Hunter uses for its own :ref:`Download <layout deployed download>` directory.
 
 
 Environment

--- a/docs/reference/user-variables.rst
+++ b/docs/reference/user-variables.rst
@@ -208,6 +208,60 @@ and have some usage peculiarities:
   for build. Combining with previous peculiarity it's expected that much
   more disk space will be used than usually.
 
+.. _hunter download server:
+
+HUNTER_DOWNLOAD_SERVER
+======================
+
+Define a list of servers to download from.
+
+We define the following packages for the examples:
+
+- Package 1 name: ``foo``
+- Package 1 SHA1: ``49dee30c5fedd8613a144f9bf6551fb46bb69e92``
+- Package 1 URL:  ``https://foo.com/downloads/foo-1.0.tar.gz``
+
+- Package 2 name: ``boo``
+- Package 2 SHA1: ``b1ec7331baf4c9996497851bfa2c847a73cd6085``
+- Package 2 URL:  ``https://server-2.com/downloads/boo-3.0.tar.gz``
+
+If ``HUNTER_DOWNLOAD_SERVER`` is empty nothing changes and the following URLs
+are used to download the sources:
+
+- ``foo``: ``https://foo.com/downloads/foo-1.0.tar.gz``
+- ``boo``: ``https://server-2.com/downloads/boo-3.0.tar.gz``
+
+If ``HUNTER_DOWNLOAD_SERVER`` is a list of servers like
+``https://server-1.com;https://server-2.com;https://server-3.com``
+then the original package URL is analyzed. If the original URL matches one of the
+defined servers we leave it untouched and set as a server with high priority.
+
+For package ``foo`` the following URLs are passed to ``ExternalProject_Add``
+(the original URL is not used):
+
+- ``https://server-1.com/foo/1.0/SHASUM/foo-1.0.tar.gz``
+- ``https://server-2.com/foo/1.0/SHASUM/foo-1.0.tar.gz``
+- ``https://server-3.com/foo/1.0/SHASUM/foo-1.0.tar.gz``
+
+For package ``boo`` the following URLs are passed to ``ExternalProject_Add``
+(the original URL has the highest priority):
+
+- ``https://server-2.com/downloads/boo-3.0.tar.gz`` (take priority, original URL used)
+- ``https://server-1.com/boo/3.0/SHASUM/boo-3.0.tar.gz``
+- ``https://server-3.com/boo/3.0/SHASUM/boo-3.0.tar.gz``
+
+
+The retry logic is implemented in the CMake function ``ExternalProject_Add``.
+
+To create new URLs the following template is used:
+
+    ``${HUNTER_DOWNLOAD_SERVER}/${PACKAGE_NAME}/${PACKAGE_VERSION}/${ARCHIVE_ID}/${filename}``
+
+- The characters ``!@#$%^&*?`` occurring in ``${filename}`` are replaced with ``_``.
+- ``${ARCHIVE_ID}`` is the first 7 characters of the package archive ``SHA1`` sum.
+- Note: This is the same structure as Hunter uses for its own ``Download`` directory.
+
+
 Environment
 ~~~~~~~~~~~
 

--- a/docs/reference/user-variables.rst
+++ b/docs/reference/user-variables.rst
@@ -250,6 +250,10 @@ For package ``boo`` the following URLs are passed to ``ExternalProject_Add``
 - ``https://server-1.com/boo/3.0/SHASUM/boo-3.0.tar.gz``
 - ``https://server-3.com/boo/3.0/SHASUM/boo-3.0.tar.gz``
 
+.. note::
+
+    Multiple URLs are supported only with CMake 3.7+. For earlier versions
+    the first listed URL is passed to ``ExternalProject_Add``.
 
 The retry logic is implemented in the CMake function ``ExternalProject_Add``.
 
@@ -259,7 +263,10 @@ To create new URLs the following template is used:
 
 - The characters ``!@#$%^&*?`` occurring in ``${filename}`` are replaced with ``_``.
 - ``${ARCHIVE_ID}`` is the first 7 characters of the package archive ``SHA1`` sum.
-- Note: This is the same structure as Hunter uses for its own ``Download`` directory.
+
+.. note::
+
+    This is the same structure as Hunter uses for its own :doc:`Download </reference/layouts/deployed>` directory.
 
 
 Environment

--- a/maintenance/download_package_for_server.sh
+++ b/maintenance/download_package_for_server.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+set -e # exit on error
+
+function print_synopsis {
+	echo "$0 [options]"
+	echo "    -h, --help       print this help message and exit."
+	echo "    --URL            original URL to download from"
+	echo "    --SHA1           SHA1 of the archive to download"
+	echo "    --PACKAGE        name of the package to download"
+	echo "    --VERSION        version of the package to download"
+	echo "    -o,--output-dir  output directory to create structure and download file into"
+}
+
+# https://stackoverflow.com/a/14203146
+# Use -gt 1 to consume two arguments per pass in the loop (e.g. each
+# argument has a corresponding value to go with it).
+# Use -gt 0 to consume one or more arguments per pass in the loop (e.g.
+# some arguments don't have a corresponding value to go with it such
+# as in the --default example).
+# note: if this is set to -gt 0 the /etc/hosts part is not recognized ( may be a bug )
+while [[ $# -gt 0 ]]
+do
+	key="$1"
+case $key in
+	-h|--help)
+		print_synopsis
+		exit 0
+	;;
+	--URL)
+		if [[ $# -lt 2 ]]; then
+			echo "'$key' needs one argument"
+			echo ""
+			print_synopsis
+			exit 1
+		fi
+		pkg_url="$2"
+		shift # past argument
+	;;
+	--SHA1)
+		if [[ $# -lt 2 ]]; then
+			echo "'$key' needs one argument"
+			echo ""
+			print_synopsis
+			exit 1
+		fi
+		pkg_sha1="$2"
+		shift # past argument
+	;;
+	--PACKAGE)
+		if [[ $# -lt 2 ]]; then
+			echo "'$key' needs one argument"
+			echo ""
+			print_synopsis
+			exit 1
+		fi
+		pkg_name="$2"
+		shift # past argument
+	;;
+	--VERSION)
+		if [[ $# -lt 2 ]]; then
+			echo "'$key' needs one argument"
+			echo ""
+			print_synopsis
+			exit 1
+		fi
+		pkg_version="$2"
+		shift # past argument
+	;;
+	-o|--output-dir)
+		if [[ $# -lt 2 ]]; then
+			echo "'$key' needs one argument"
+			echo ""
+			print_synopsis
+			exit 1
+		fi
+		output_dir="$2"
+		shift # past argument
+	;;
+	*)
+		# unknown option
+		echo "error: unknown option '$key'"
+		echo ""
+		print_synopsis
+		exit 1
+    ;;
+esac
+shift # past argument or value
+done
+
+# check for mandatory parameter
+if [ -z ${pkg_url+x} ]; then
+	echo "parameter '--URL' is mandatory"
+	echo ""
+	print_synopsis
+	exit 1
+fi
+if [ -z ${pkg_sha1+x} ]; then
+	echo "parameter '--SHA1' is mandatory"
+	echo ""
+	print_synopsis
+	exit 1
+fi
+if [ -z ${pkg_name+x} ]; then
+	echo "parameter '--PACKAGE' is mandatory"
+	echo ""
+	print_synopsis
+	exit 1
+fi
+if [ -z ${pkg_version+x} ]; then
+	echo "parameter '--VERSION' is mandatory"
+	echo ""
+	print_synopsis
+	exit 1
+fi
+
+# if output directory is set check if it exists
+if [ ! -z ${output_dir+x} ]; then
+	if [ ! -d "${output_dir}" ]; then
+		echo "output directory does not exist: \"${output_dir}\""
+		exit 1
+	fi
+	# let output dir end with /
+	case ${output_dir} in
+		*/)
+			# echo "all good, nothing to do"
+		;;
+		*)
+			output_dir="${output_dir}/"
+		;;
+	esac
+fi
+
+# show every executed command
+set -x
+
+# use first 7 characters of SHA1 as archive-ID
+pkg_archive_id="${pkg_sha1:0:7}"
+# define directory structure
+pkg_target_structure="${output_dir}${pkg_name}/${pkg_version}/${pkg_archive_id}"
+# extract filename from download URL
+pkg_target_filename=$(basename "$pkg_url" | sed -e 's/[!@#$%^&*?]/_/g')
+
+mkdir -p "$pkg_target_structure"
+wget "$pkg_url" -O "${pkg_target_structure}/${pkg_target_filename}" --no-check-certificate
+


### PR DESCRIPTION
- add cmake option HUNTER_DOWNLOAD_SERVER
- if set the packages are downloaded from the specified download server
  instead of the original URL
- the following charactes in the package filename are replaced by '_':
  !@#$%^&*?
- the new URL has the following setup:
  "${HUNTER_DOWNLOAD_SERVER}/${HUNTER_PACKAGE_NAME}/${HUNTER_PACKAGE_VERSION}/${package_filename}"
- HUNTER_DOWNLOAD_SERVER_BLACKLIST can be used to provide a list of URLs
  to NOT use the download server. For example
  -DHUNTER_DOWNLOAD_SERVER_BLACKLIST="github.com"

also adds a shell script to download a package and put it into the expected directory structure