### PR TITLE
Fix issue1112

### DIFF
--- a/cmake/projects/GTest/hunter.cmake
+++ b/cmake/projects/GTest/hunter.cmake
@@ -196,7 +196,7 @@ hunter_add_version(
 
 # The regexp case is used when the package is added as GIT_SUBMODULE.
 # In this case we assume that the version is later than 1.8.0.
-if(HUNTER_GTest_VERSION VERSION_LESS 1.8.0 AND NOT A MATCHES "^[a-z0-9]{40}$" )
+if(HUNTER_GTest_VERSION VERSION_LESS 1.8.0 AND NOT A MATCHES "[a-z]+" )
   set(_gtest_license "LICENSE")
 else()
   set(_gtest_license "googletest/LICENSE")

--- a/cmake/projects/GTest/hunter.cmake
+++ b/cmake/projects/GTest/hunter.cmake
@@ -194,7 +194,9 @@ hunter_add_version(
     ab0f563b3bd80a1721cb93df034a86ec
 )
 
-if(HUNTER_GTest_VERSION VERSION_LESS 1.8.0)
+# The regexp case is used when the package is added as GIT_SUBMODULE.
+# In this case we assume that the version is later than 1.8.0.
+if(HUNTER_GTest_VERSION VERSION_LESS 1.8.0 AND NOT MATCHES "^[a-z0-9]{40}$")
   set(_gtest_license "LICENSE")
 else()
   set(_gtest_license "googletest/LICENSE")

--- a/cmake/projects/GTest/hunter.cmake
+++ b/cmake/projects/GTest/hunter.cmake
@@ -196,7 +196,7 @@ hunter_add_version(
 
 # The regexp case is used when the package is added as GIT_SUBMODULE.
 # In this case we assume that the version is later than 1.8.0.
-if(HUNTER_GTest_VERSION VERSION_LESS 1.8.0 AND NOT ( MATCHES "^[a-z0-9]{40}$" ))
+if(HUNTER_GTest_VERSION VERSION_LESS 1.8.0 AND NOT A MATCHES "^[a-z0-9]{40}$" )
   set(_gtest_license "LICENSE")
 else()
   set(_gtest_license "googletest/LICENSE")

--- a/cmake/projects/GTest/hunter.cmake
+++ b/cmake/projects/GTest/hunter.cmake
@@ -196,7 +196,7 @@ hunter_add_version(
 
 # The regexp case is used when the package is added as GIT_SUBMODULE.
 # In this case we assume that the version is later than 1.8.0.
-if(HUNTER_GTest_VERSION VERSION_LESS 1.8.0 AND NOT MATCHES "^[a-z0-9]{40}$")
+if(HUNTER_GTest_VERSION VERSION_LESS 1.8.0 AND NOT ( MATCHES "^[a-z0-9]{40}$" ))
   set(_gtest_license "LICENSE")
 else()
   set(_gtest_license "googletest/LICENSE")

--- a/cmake/projects/GTest/hunter.cmake
+++ b/cmake/projects/GTest/hunter.cmake
@@ -183,6 +183,17 @@ hunter_add_version(
     4fe083a96d7597f7dce6f453dca01e1d94a1e45b
 )
 
+hunter_add_version(
+    PACKAGE_NAME
+    GTest
+    VERSION
+    1.8.0-hunter-p8
+    URL
+    "https://github.com/hunter-packages/googletest/archive/1.8.0-hunter-p8.tar.gz"
+    SHA1
+    ab0f563b3bd80a1721cb93df034a86ec
+)
+
 if(HUNTER_GTest_VERSION VERSION_LESS 1.8.0)
   set(_gtest_license "LICENSE")
 else()


### PR DESCRIPTION
I did two things.
1. Add the latest release of the GTest package. It seems that this was forgotten.
2. Added a fix for #1112 by modifiying the conditional. When using the package in GIT_SUBMODULE mode, its version is the 40 character long hash, which is matched by the regexp. In this case we assume that the version is newer than 1.8.0 and take the lower branch. This can still cause errors when the submodule is set to the old package repository, but I think in most cases the GIT_SUBMODULE option is used when working on the new package.

