### PR TITLE
Fix build error in PocoCpp when POCO_UNBUNDLED is ON.

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -100,7 +100,7 @@ hunter_config(OpenCV-Extra VERSION 3.3.1)
 hunter_config(OpenNMTTokenizer VERSION 0.2.0-p1)
 hunter_config(OpenSSL VERSION 1.1.0g)
 hunter_config(PNG VERSION 1.6.26-p1)
-hunter_config(PocoCpp VERSION 1.7.9-p0)
+hunter_config(PocoCpp VERSION 1.7.9-p1)
 hunter_config(PostgreSQL VERSION 10.0.0)
 hunter_config(Protobuf VERSION 3.3.0)
 

--- a/cmake/projects/PocoCpp/hunter.cmake
+++ b/cmake/projects/PocoCpp/hunter.cmake
@@ -8,6 +8,17 @@ hunter_add_version(
     PACKAGE_NAME
     PocoCpp
     VERSION
+    1.7.9-p1
+    URL
+    "https://github.com/hunter-packages/poco/archive/v1.7.9-p1.zip"
+    SHA1
+    28adb9a84af3000dde5525c14e906f5f5ea095f3
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    PocoCpp
+    VERSION
     1.7.9-p0
     URL
     "https://github.com/hunter-packages/poco/archive/v1.7.9-p0.zip"


### PR DESCRIPTION
In [v1.7.9-p0](https://github.com/hunter-packages/poco/releases/tag/v1.7.9-p0), fixed a build error when POCO_UNBUNLDED is enabled. (is disabled by default. Thats why Hunter CI could not report the error).

Changes:
- Hunterize ZLIB and SQLite3 libs inside Poco. See, [commit](https://github.com/hunter-packages/poco/commit/1d54098e8a9f4f02c5f12f8ec69ffa176d34f6cb).

Retained v1.7.9-p0 but will cause error when POCO_UNBUNLDED is enabled