### PR TITLE
New CMAKE_ARGS options for Boost to append config macros to boost config

### DIFF
--- a/cmake/projects/Boost/atomic/hunter.cmake
+++ b/cmake/projects/Boost/atomic/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     atomic
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/chrono/hunter.cmake
+++ b/cmake/projects/Boost/chrono/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     chrono
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/context/hunter.cmake
+++ b/cmake/projects/Boost/context/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     context
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/coroutine/hunter.cmake
+++ b/cmake/projects/Boost/coroutine/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     coroutine
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/date_time/hunter.cmake
+++ b/cmake/projects/Boost/date_time/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     date_time
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/exception/hunter.cmake
+++ b/cmake/projects/Boost/exception/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     exception
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/filesystem/hunter.cmake
+++ b/cmake/projects/Boost/filesystem/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     filesystem
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/graph/hunter.cmake
+++ b/cmake/projects/Boost/graph/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/graph_parallel/hunter.cmake
+++ b/cmake/projects/Boost/graph_parallel/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph_parallel
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -280,4 +280,4 @@ hunter_add_version(
 
 hunter_pick_scheme(DEFAULT url_sha1_boost)
 hunter_cacheable(Boost)
-hunter_download(PACKAGE_NAME Boost PACKAGE_INTERNAL_DEPS_ID "17")
+hunter_download(PACKAGE_NAME Boost PACKAGE_INTERNAL_DEPS_ID "18")

--- a/cmake/projects/Boost/hunter.cmake.in
+++ b/cmake/projects/Boost/hunter.cmake.in
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     boost_component
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/iostreams/hunter.cmake
+++ b/cmake/projects/Boost/iostreams/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     iostreams
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/locale/hunter.cmake
+++ b/cmake/projects/Boost/locale/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     locale
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/log/hunter.cmake
+++ b/cmake/projects/Boost/log/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     log
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/math/hunter.cmake
+++ b/cmake/projects/Boost/math/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     math
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/mpi/hunter.cmake
+++ b/cmake/projects/Boost/mpi/hunter.cmake
@@ -26,5 +26,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     mpi
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/program_options/hunter.cmake
+++ b/cmake/projects/Boost/program_options/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     program_options
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/python/hunter.cmake
+++ b/cmake/projects/Boost/python/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     python
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/random/hunter.cmake
+++ b/cmake/projects/Boost/random/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     random
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/regex/hunter.cmake
+++ b/cmake/projects/Boost/regex/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     regex
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/schemes/url_sha1_boost.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost.cmake.in
@@ -100,6 +100,10 @@ ExternalProject_Add(
     INSTALL_DIR
     "@HUNTER_PACKAGE_INSTALL_PREFIX@"
         # not used, just avoid creating Install/<name> empty directory
+    UPDATE_COMMAND
+    "@CMAKE_COMMAND@" -P
+    "@HUNTER_GLOBAL_SCRIPT_DIR@/append-boost-config-macros.cmake"
+    "@HUNTER_Boost_CMAKE_ARGS@"
     CONFIGURE_COMMAND
     ${env_cmd}
     COMMAND

--- a/cmake/projects/Boost/schemes/url_sha1_boost_ios_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_ios_library.cmake.in
@@ -310,6 +310,10 @@ ExternalProject_Add(
     INSTALL_DIR
     "@HUNTER_PACKAGE_INSTALL_PREFIX@"
         # not used, just avoid creating Install/<name> empty directory
+    UPDATE_COMMAND
+    "@CMAKE_COMMAND@" -P
+    "@HUNTER_GLOBAL_SCRIPT_DIR@/append-boost-config-macros.cmake"
+    "@HUNTER_Boost_CMAKE_ARGS@"
     CONFIGURE_COMMAND
     ""
     BUILD_COMMAND

--- a/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
@@ -355,6 +355,10 @@ ExternalProject_Add(
     INSTALL_DIR
     "@HUNTER_PACKAGE_INSTALL_PREFIX@"
         # not used, just avoid creating Install/<name> empty directory
+    UPDATE_COMMAND
+    "@CMAKE_COMMAND@" -P
+    "@HUNTER_GLOBAL_SCRIPT_DIR@/append-boost-config-macros.cmake"
+    "@HUNTER_Boost_CMAKE_ARGS@"
     CONFIGURE_COMMAND
     ${env_cmd}
     ${copy_mpi_command}

--- a/cmake/projects/Boost/serialization/hunter.cmake
+++ b/cmake/projects/Boost/serialization/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     serialization
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/signals/hunter.cmake
+++ b/cmake/projects/Boost/signals/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     signals
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/system/hunter.cmake
+++ b/cmake/projects/Boost/system/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     system
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/test/hunter.cmake
+++ b/cmake/projects/Boost/test/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     test
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/thread/hunter.cmake
+++ b/cmake/projects/Boost/thread/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     thread
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/timer/hunter.cmake
+++ b/cmake/projects/Boost/timer/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     timer
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/cmake/projects/Boost/wave/hunter.cmake
+++ b/cmake/projects/Boost/wave/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     wave
-    PACKAGE_INTERNAL_DEPS_ID "17"
+    PACKAGE_INTERNAL_DEPS_ID "18"
 )

--- a/docs/packages/pkg/Boost.rst
+++ b/docs/packages/pkg/Boost.rst
@@ -87,7 +87,7 @@ config file (boost/config/user.hpp):
 
   .. code-block:: cmake
 
-    hunter_config(Boost ${HUNTER_Boost_VERSION} ... CMAKE_ARGS IOSTREAMS_NO_BZIP2=1)
+    hunter_config(Boost ${HUNTER_Boost_VERSION} CMAKE_ARGS IOSTREAMS_NO_BZIP2=1)
     # add NO_BZIP2=1 to the b2 build of iostreams library, i.e. `b2 -s NO_BZIP2=1`
 
 -  `boost.iostreams
@@ -101,7 +101,7 @@ config file (boost/config/user.hpp):
 
   .. code-block:: cmake
 
-    hunter_config(Boost ${HUNTER_Boost_VERSION} ... CMAKE_ARGS
+    hunter_config(Boost ${HUNTER_Boost_VERSION} CMAKE_ARGS
         CONFIG_MACRO=BOOST_REGEX_MATCH_EXTRA;BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
         CONFIG_MACRO_BOOST_MPL_LIMIT_LIST_SIZE=3
     )

--- a/docs/packages/pkg/Boost.rst
+++ b/docs/packages/pkg/Boost.rst
@@ -87,7 +87,7 @@ config file (boost/config/user.hpp):
 
   .. code-block:: cmake
 
-    hunter_config(Boost VERSION ... CMAKE_ARGS IOSTREAMS_NO_BZIP2=1)
+    hunter_config(Boost ${HUNTER_Boost_VERSION} ... CMAKE_ARGS IOSTREAMS_NO_BZIP2=1)
     # add NO_BZIP2=1 to the b2 build of iostreams library, i.e. `b2 -s NO_BZIP2=1`
 
 -  `boost.iostreams
@@ -101,7 +101,7 @@ config file (boost/config/user.hpp):
 
   .. code-block:: cmake
 
-    hunter_config(Boost VERSION ... CMAKE_ARGS
+    hunter_config(Boost ${HUNTER_Boost_VERSION} ... CMAKE_ARGS
         CONFIG_MACRO=BOOST_REGEX_MATCH_EXTRA;BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
         CONFIG_MACRO_BOOST_MPL_LIMIT_LIST_SIZE=3
     )

--- a/docs/packages/pkg/Boost.rst
+++ b/docs/packages/pkg/Boost.rst
@@ -110,13 +110,6 @@ config file (boost/config/user.hpp):
     # #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
     # #define CONFIG_MACRO_BOOST_MPL_LIMIT_LIST_SIZE 3
 
-  .. note::
-
-      If you define BOOST_USER_CONFIG to use a non default boot user config
-      file make sure to include the default boot user config
-      file (boost/config/user.hpp) or define the same set of config macros
-      used to build boost libs.
-
 Math
 ----
 

--- a/docs/packages/pkg/Boost.rst
+++ b/docs/packages/pkg/Boost.rst
@@ -75,20 +75,47 @@ Compatibility mode
 CMake options
 -------------
 
-CMake options can be passed to boost build using ``CMAKE_ARGS`` feature
+You can use ``CMAKE_ARGS`` feature
 (see
-`customization <https://github.com/ruslo/hunter/wiki/example.custom.config.id#custom-cmake-options>`__).
-Options of special form ``<COMPONENT-UPPERCASE>_<OPTION>=<VALUE>`` will
-be added to ``b2`` as ``-s <OPTION>=<VALUE>`` while building component .
-For example:
+`customization <https://github.com/ruslo/hunter/wiki/example.custom.config.id#custom-cmake-options>`__)
+to pass options to boost build or to append config macros in the default boost user
+config file (boost/config/user.hpp):
 
-.. code-block:: cmake
+- Options of special form ``<COMPONENT-UPPERCASE>_<OPTION>=<VALUE>`` will
+  be added to ``b2`` as ``-s <OPTION>=<VALUE>`` while building component .
+  For example:
+
+  .. code-block:: cmake
 
     hunter_config(Boost VERSION ... CMAKE_ARGS IOSTREAMS_NO_BZIP2=1)
     # add NO_BZIP2=1 to the b2 build of iostreams library, i.e. `b2 -s NO_BZIP2=1`
 
 -  `boost.iostreams
    options <http://www.boost.org/doc/libs/1_57_0/libs/iostreams/doc/index.html?path=7>`__
+
+- Options ``CONFIG_MACRO_<ID>=<VALUE>`` will append ``#define <ID> <VALUE>``
+  to the default boost user config file. And options
+  ``CONFIG_MACRO=<ID_1>;<ID_2>;...;<ID_n>`` will append ``#define <ID_1>``,
+  ``#define <ID_2>``, ..., ``#define <ID_n>``.
+  Example:
+
+  .. code-block:: cmake
+
+    hunter_config(Boost VERSION ... CMAKE_ARGS
+        CONFIG_MACRO=BOOST_REGEX_MATCH_EXTRA;BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
+        CONFIG_MACRO_BOOST_MPL_LIMIT_LIST_SIZE=3
+    )
+    # append the next lines to boost/config/user.hpp:
+    # #define BOOST_REGEX_MATCH_EXTRA
+    # #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
+    # #define CONFIG_MACRO_BOOST_MPL_LIMIT_LIST_SIZE 3
+
+  .. note::
+
+      If you define BOOST_USER_CONFIG to use a non default boot user config
+      file make sure to include the default boot user config
+      file (boost/config/user.hpp) or define the same set of config macros
+      used to build boost libs.
 
 Math
 ----

--- a/scripts/append-boost-config-macros.cmake
+++ b/scripts/append-boost-config-macros.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.0)
+
 # run at the boost source root
 set(boost_user_config_file "boost/config/user.hpp")
 

--- a/scripts/append-boost-config-macros.cmake
+++ b/scripts/append-boost-config-macros.cmake
@@ -1,0 +1,33 @@
+# run at the boost source root
+set(boost_user_config_file "boost/config/user.hpp")
+
+set(define_without_value_mode FALSE)
+
+foreach(i RANGE ${CMAKE_ARGC})
+
+  if (define_without_value_mode)
+    if ("${CMAKE_ARGV${i}}" MATCHES "[^=]+=.+")
+      set(define_without_value_mode FALSE)
+    endif()
+  endif()
+
+  unset(append_str)
+
+  if(define_without_value_mode)
+      # CONFIG_MACRO=id_1 id_2 ... id_n -> #define id_n
+      set(append_str "#define ${CMAKE_ARGV${i}}")
+  elseif("${CMAKE_ARGV${i}}" MATCHES "^CONFIG_MACRO=(.+)" )
+    # CONFIG_MACRO=id_1 id_2 ... id_n -> #define id_1
+    set(append_str "#define ${CMAKE_MATCH_1}")
+    set(define_without_value_mode TRUE)
+  elseif("${CMAKE_ARGV${i}}" MATCHES "^CONFIG_MACRO_([^=]+)=(.+)" )
+    # CONFIG_MACRO_id=val -> #define id val
+    set(append_str "#define ${CMAKE_MATCH_1} ${CMAKE_MATCH_2}")
+  endif()
+
+  if(append_str)
+    message("-- append '${append_str}' to '${boost_user_config_file}'")
+    file(APPEND "${boost_user_config_file}" "${append_str}")
+  endif()
+
+endforeach()

--- a/scripts/append-boost-config-macros.cmake
+++ b/scripts/append-boost-config-macros.cmake
@@ -27,7 +27,7 @@ foreach(i RANGE ${CMAKE_ARGC})
 
   if(append_str)
     message("-- append '${append_str}' to '${boost_user_config_file}'")
-    file(APPEND "${boost_user_config_file}" "${append_str}")
+    file(APPEND "${boost_user_config_file}" "\n${append_str}\n")
   endif()
 
 endforeach()


### PR DESCRIPTION
Users of Boost can define some configuration macros. This configuration
macros can affect non headers only/compiled boost component. To keep the
same configuration between compiled boost components and projects that
will use those components, configurations macros are append to the default
boost user config file (boost/config/user.hpp). Configuration macros can be
defined using new CMAKE_ARGS options in hunter_config() for boost.

Fixes ruslo/hunter#1078 and fixes ruslo/hunter#906