### PR TITLE
add KEEP_PACKAGE_SOURCES option to hunter_config()

### DIFF
--- a/cmake/modules/hunter_calculate_config_sha1.cmake
+++ b/cmake/modules/hunter_calculate_config_sha1.cmake
@@ -128,11 +128,6 @@ function(hunter_calculate_config_sha1 hunter_self hunter_base user_config)
         )
       endif()
 
-      string(COMPARE NOTEQUAL "{HUNTER_${x}_KEEP_PACKAGE_SOURCES}" "" have_keep_package_sources)
-      if(have_keep_package_sources)
-        file(APPEND "${input_file}" " KEEP_PACKAGE_SOURCES")
-      endif()
-      
       file(APPEND "${input_file}" ")\n")
     endif()
   endforeach()

--- a/cmake/modules/hunter_calculate_config_sha1.cmake
+++ b/cmake/modules/hunter_calculate_config_sha1.cmake
@@ -128,6 +128,11 @@ function(hunter_calculate_config_sha1 hunter_self hunter_base user_config)
         )
       endif()
 
+      string(COMPARE NOTEQUAL "{HUNTER_${x}_KEEP_PACKAGE_SOURCES}" "" have_keep_package_sources)
+      if(have_keep_package_sources)
+        file(APPEND "${input_file}" " KEEP_PACKAGE_SOURCES")
+      endif()
+      
       file(APPEND "${input_file}" ")\n")
     endif()
   endforeach()

--- a/cmake/modules/hunter_config.cmake
+++ b/cmake/modules/hunter_config.cmake
@@ -93,4 +93,6 @@ macro(hunter_config)
     set(HUNTER_${_hunter_current_project}_KEEP_PACKAGE_SOURCES ON)
   endif()
 
+  message("MOD: ${_hunter_current_project}  ${HUNTER_${_hunter_current_project}_KEEP_PACKAGE_SOURCES}")
+
 endmacro()

--- a/cmake/modules/hunter_config.cmake
+++ b/cmake/modules/hunter_config.cmake
@@ -90,9 +90,12 @@ macro(hunter_config)
   endif()
 
   if(_hunter_KEEP_PACKAGE_SOURCES)
-    set(HUNTER_${_hunter_current_project}_KEEP_PACKAGE_SOURCES ON)
+    set_property(
+      GLOBAL
+      PROPERTY
+      "HUNTER_${_hunter_current_project}_KEEP_PACKAGE_SOURCES"
+      ON
+      )
   endif()
-
-  message("MOD: ${_hunter_current_project}  ${HUNTER_${_hunter_current_project}_KEEP_PACKAGE_SOURCES}")
 
 endmacro()

--- a/cmake/modules/hunter_config.cmake
+++ b/cmake/modules/hunter_config.cmake
@@ -18,11 +18,12 @@ macro(hunter_config)
         "error.unexpected.hunter_config"
     )
   endif()
+  set(_hunter_optional KEEP_PACKAGE_SOURCES)
   set(_hunter_one_value VERSION GIT_SUBMODULE GIT_SUBMODULE_DIR)
   set(_hunter_multiple_values CMAKE_ARGS CONFIGURATION_TYPES)
   cmake_parse_arguments(
       _hunter
-      ""
+      "${_hunter_optional}"
       "${_hunter_one_value}"
       "${_hunter_multiple_values}"
       ${ARGV}
@@ -87,4 +88,9 @@ macro(hunter_config)
   else()
     hunter_user_error("Expected VERSION option for 'hunter_config' command")
   endif()
+
+  if(_hunter_KEEP_PACKAGE_SOURCES)
+    set(HUNTER_${_hunter_current_project}_KEEP_PACKAGE_SOURCES ON)
+  endif()
+
 endmacro()

--- a/cmake/modules/hunter_download.cmake
+++ b/cmake/modules/hunter_download.cmake
@@ -382,12 +382,20 @@ function(hunter_download)
   file(REMOVE "${HUNTER_PACKAGE_HOME_DIR}/CMakeLists.txt")
   file(REMOVE "${HUNTER_DOWNLOAD_TOOLCHAIN}")
 
+  get_property(
+    keep_sources
+    GLOBAL
+    PROPERTY
+    "HUNTER_${h_name}_KEEP_PACKAGE_SOURCES"
+    )
+
   if(HUNTER_KEEP_PACKAGE_SOURCES OR HUNTER_${h_name}_KEEP_PACKAGE_SOURCES)
     set(_hunter_keep_package_sources ON)
   else()
     set(_hunter_keep_package_sources OFF)
   endif()
-
+  hunter_status_debug("Keep package sources: ${_hunter_keep_package_sources}")
+  
   file(WRITE "${HUNTER_DOWNLOAD_TOOLCHAIN}" "")
 
   hunter_jobs_number(HUNTER_JOBS_OPTION "${HUNTER_DOWNLOAD_TOOLCHAIN}")

--- a/cmake/modules/hunter_download.cmake
+++ b/cmake/modules/hunter_download.cmake
@@ -429,7 +429,7 @@ function(hunter_download)
   file(
       APPEND
       "${HUNTER_DOWNLOAD_TOOLCHAIN}"
-      "set(HUNTER_KEEP_PACKAGE_SOURCES \"${HUNTER_KEEP_PACKAGE_SOURCES}\" CACHE INTERNAL \"\")\n"
+      "set(HUNTER_KEEP_PACKAGE_SOURCES \"${_hunter_keep_package_sources}\" CACHE INTERNAL \"\")\n"
   )
   file(
       APPEND
@@ -628,9 +628,13 @@ function(hunter_download)
 
   hunter_status_debug("Cleaning up build directories...")
 
+  if(HUNTER_KEEP_PACKAGE_SOURCES OR HUNTER_${h_name}_KEEP_PACKAGE_SOURCES)
+    set(_hunter_keep_package_sources ON)
+  endif()
+  
   file(REMOVE_RECURSE "${HUNTER_PACKAGE_BUILD_DIR}")
   if(HUNTER_PACKAGE_SCHEME_INSTALL)
-    if(HUNTER_KEEP_PACKAGE_SOURCES)
+    if(_hunter_keep_package_sources)
       hunter_status_debug("Keep source directory '${HUNTER_PACKAGE_SOURCE_DIR}'")
     else()
       # Unpacked directory not needed (save some disk space)

--- a/cmake/modules/hunter_download.cmake
+++ b/cmake/modules/hunter_download.cmake
@@ -382,6 +382,10 @@ function(hunter_download)
   file(REMOVE "${HUNTER_PACKAGE_HOME_DIR}/CMakeLists.txt")
   file(REMOVE "${HUNTER_DOWNLOAD_TOOLCHAIN}")
 
+  if(HUNTER_KEEP_PACKAGE_SOURCES OR HUNTER_${h_name}_KEEP_PACKAGE_SOURCES)
+    set(_hunter_keep_package_sources ON)
+  endif()  
+
   file(WRITE "${HUNTER_DOWNLOAD_TOOLCHAIN}" "")
 
   hunter_jobs_number(HUNTER_JOBS_OPTION "${HUNTER_DOWNLOAD_TOOLCHAIN}")
@@ -627,10 +631,6 @@ function(hunter_download)
   hunter_save_to_cache()
 
   hunter_status_debug("Cleaning up build directories...")
-
-  if(HUNTER_KEEP_PACKAGE_SOURCES OR HUNTER_${h_name}_KEEP_PACKAGE_SOURCES)
-    set(_hunter_keep_package_sources ON)
-  endif()
   
   file(REMOVE_RECURSE "${HUNTER_PACKAGE_BUILD_DIR}")
   if(HUNTER_PACKAGE_SCHEME_INSTALL)

--- a/cmake/modules/hunter_download.cmake
+++ b/cmake/modules/hunter_download.cmake
@@ -384,7 +384,9 @@ function(hunter_download)
 
   if(HUNTER_KEEP_PACKAGE_SOURCES OR HUNTER_${h_name}_KEEP_PACKAGE_SOURCES)
     set(_hunter_keep_package_sources ON)
-  endif()  
+  else()
+    set(_hunter_keep_package_sources OFF)
+  endif()
 
   file(WRITE "${HUNTER_DOWNLOAD_TOOLCHAIN}" "")
 
@@ -433,7 +435,7 @@ function(hunter_download)
   file(
       APPEND
       "${HUNTER_DOWNLOAD_TOOLCHAIN}"
-      "set(HUNTER_KEEP_PACKAGE_SOURCES \"${_hunter_keep_package_sources}\" CACHE INTERNAL \"\")\n"
+      "set(HUNTER_KEEP_PACKAGE_SOURCES \"${HUNTER_KEEP_PACKAGE_SOURCES}\" CACHE INTERNAL \"\")\n"
   )
   file(
       APPEND

--- a/cmake/modules/hunter_download.cmake
+++ b/cmake/modules/hunter_download.cmake
@@ -389,7 +389,7 @@ function(hunter_download)
     "HUNTER_${h_name}_KEEP_PACKAGE_SOURCES"
     )
 
-  if(HUNTER_KEEP_PACKAGE_SOURCES OR HUNTER_${h_name}_KEEP_PACKAGE_SOURCES)
+  if(HUNTER_KEEP_PACKAGE_SOURCES OR keep_sources)
     set(_hunter_keep_package_sources ON)
   else()
     set(_hunter_keep_package_sources OFF)


### PR DESCRIPTION
PR for initial review/discussion:
* append `KEEP_PACKAGE_SOURCES` option in hunter_calculate_config_sha1.cmake if specified
* introduce _hunter_keep_package_sources in hunter_download.cmake as logical OR of global `HUNTER_KEEP_PACKAGE_SOURCES` and local `HUNTER_${h_name}_KEEP_PACKAGE_SOURCES`