### PR TITLE
Crypt32 required for all Windows

### DIFF
--- a/cmake/find/FindOpenSSL.cmake
+++ b/cmake/find/FindOpenSSL.cmake
@@ -374,14 +374,14 @@ if(OPENSSL_FOUND)
     set_target_properties(OpenSSL::Crypto PROPERTIES
       INTERFACE_INCLUDE_DIRECTORIES "${OPENSSL_INCLUDE_DIR}")
     find_package(Threads REQUIRED)
-    if(MINGW)
+    if(WIN32)
       # https://github.com/openssl/openssl/issues/1061
-      set(_openssl_mingw_crypt "crypt32")
+      set(_openssl_win32_crypt "crypt32")
     else()
-      set(_openssl_mingw_crypt "")
+      set(_openssl_win32_crypt "")
     endif()
     set_target_properties(OpenSSL::Crypto PROPERTIES
-        INTERFACE_LINK_LIBRARIES "${CMAKE_DL_LIBS};Threads::Threads;${_openssl_mingw_crypt}")
+        INTERFACE_LINK_LIBRARIES "${CMAKE_DL_LIBS};Threads::Threads;${_openssl_win32_crypt}")
     if(EXISTS "${OPENSSL_CRYPTO_LIBRARY}")
       set_target_properties(OpenSSL::Crypto PROPERTIES
         IMPORTED_LINK_INTERFACE_LANGUAGES "C"


### PR DESCRIPTION
I found an unresolved symbol issue tracked back to missing crypt32 that appeared to only be resolved for MinGW in Hunter.

libcrypto.lib(e_capi.obj) : error LNK2001: unresolved external symbol __imp_CertOpenStore [Y:\J\workspace\...\...\....vcxproj]

So I have added it for all WIN32 instead.