### PR TITLE
cannot build libxml2 on different drive in windows fixed

### DIFF
--- a/cmake/projects/libxml2/scripts/patched_bootstrap.bat.in
+++ b/cmake/projects/libxml2/scripts/patched_bootstrap.bat.in
@@ -1,4 +1,4 @@
 call "@HUNTER_MSVC_VCVARSALL@" @HUNTER_MSVC_ARCH@
-cd @HUNTER_PACKAGE_SOURCE_DIR@/win32
+cd /D @HUNTER_PACKAGE_SOURCE_DIR@/win32
 cscript //B configure.js @shared@ compiler=msvc "cruntime=@LIBXML2_RUNTIME@" "prefix=@LIBXML2_INSTALL_DIR@" iconv=no debug=no zlib=no http=no ftp=no
 nmake /f Makefile.msvc libxml install-libs


### PR DESCRIPTION
Added /D to cd in patched_bootstrap.cmd
This enables HUNTER_ROOT to be on a different directory