### PR TITLE
Fix location of version_not_found check

### DIFF
--- a/cmake/modules/hunter_download.cmake
+++ b/cmake/modules/hunter_download.cmake
@@ -1,5 +1,6 @@
-# Copyright (c) 2013-2017, Ruslan Baratov
-# Copyright (c) 2015, Aaditya Kalsi
+# Copyright (c) 2013-2018, Ruslan Baratov
+# Copyright (c) 2015-2018, Aaditya Kalsi
+# Copyright (c) 2018, David Hirvonen
 # All rights reserved.
 
 include(CMakeParseArguments) # cmake_parse_arguments

--- a/cmake/modules/hunter_download.cmake
+++ b/cmake/modules/hunter_download.cmake
@@ -80,6 +80,12 @@ function(hunter_download)
   set(HUNTER_PACKAGE_VERSION "${HUNTER_${h_name}_VERSION}")
   set(ver "${HUNTER_PACKAGE_VERSION}")
   set(HUNTER_PACKAGE_SHA1 "${HUNTER_${h_name}_SHA1}")
+
+  string(COMPARE EQUAL "${HUNTER_PACKAGE_SHA1}" "" version_not_found)
+  if(version_not_found)
+    hunter_user_error("Version not found: ${ver}. See 'hunter_config' command.")
+  endif()
+  
   # set download URL, either direct download or redirected if HUNTER_DOWNLOAD_SERVER is set
   hunter_download_server_url(
     PACKAGE "${HUNTER_PACKAGE_NAME}"
@@ -110,11 +116,6 @@ function(hunter_download)
   hunter_test_string_not_empty("${HUNTER_PACKAGE_CONFIGURATION_TYPES}")
 
   string(COMPARE EQUAL "${HUNTER_PACKAGE_URL}" "" hunter_no_url)
-
-  string(COMPARE EQUAL "${HUNTER_PACKAGE_SHA1}" "" version_not_found)
-  if(version_not_found)
-    hunter_user_error("Version not found: ${ver}. See 'hunter_config' command.")
-  endif()
 
   hunter_test_string_not_empty("${HUNTER_PACKAGE_URL}")
   hunter_test_string_not_empty("${HUNTER_PACKAGE_SHA1}")


### PR DESCRIPTION
* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.0 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

---

If a `hunter_config()` call specifies a `VERSION` that isn’t defined by a `hunter_add_version()` call (hunter/cmake/<package>/hunter.cmake), perhaps due to a typo, then a call to `hunter_download_server_url()` will be made with an empty `VERSION`, and the reported error looks like this:

```
-- [hunter *** DEBUG *** 2018-02-03T17:12:33] Foo versions available: [1.0.9999999]

[hunter ** INTERNAL **] 'hunter_download_server_url' incorrect usage
[hunter ** INTERNAL **]  option 'SHA1' with one argument is mandatory.
```

In this case may have asked for something like `hunter_config(Foo VERSION 1.0.0)`, or a typo `hunter_config(FOO VERSION 1.0.0y)`, but only a valid `VERSION` `1.0.9999999` exists.

This PR moves the existing HUNTER_PACKAGE_SHA1 version_not_found test above the call to `hunter_download_server_url()`, such that a more intuitive error is reported with the strong: "Version not found: ${ver}. See 'hunter_config' command."

With this change, the log listed above then becomes more human readable:

```
-- [hunter *** DEBUG *** 2018-02-03T17:15:09] FunctionalPlus versions available: [1.0.9999999]

[hunter ** FATAL ERROR **] Version not found: 1.0.0. See 'hunter_config' command.
```

and the developer can more easily diagnose and fix the source of the VERSION mismatch error.
