### PR TITLE
Update Protobuf to v3.5.2

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -109,7 +109,7 @@ hunter_config(OpenSSL VERSION 1.1.0g)
 hunter_config(PNG VERSION 1.6.26-p1)
 hunter_config(PocoCpp VERSION 1.7.9-p1)
 hunter_config(PostgreSQL VERSION 10.0.0)
-hunter_config(Protobuf VERSION 3.3.0)
+hunter_config(Protobuf VERSION 3.5.2-p0)
 
 string(COMPARE EQUAL "${CMAKE_SYSTEM_NAME}" "Linux" _is_linux)
 if(_is_linux OR MINGW)

--- a/cmake/projects/Protobuf/hunter.cmake
+++ b/cmake/projects/Protobuf/hunter.cmake
@@ -72,6 +72,12 @@ hunter_add_version(
     8815a6be8188b2d6c8002924e752018b64658748
 )
 
+hunter_add_version(
+    PACKAGE_NAME Protobuf
+    VERSION "3.5.2-p0"
+    URL "https://github.com/hunter-packages/protobuf/archive/v3.5.2-p0.tar.gz"
+    SHA1 "0c1eacb460266dea7cd18c2009642fa192c15b70")
+
 if(ANDROID OR IOS)
   hunter_cmake_args(
       Protobuf


### PR DESCRIPTION
* I've tested this package remotely and have excluded all broken builds.
  Here is the links to the Travis/AppVeyor with status "All passed":

  * https://ci.appveyor.com/project/isaachier/hunter/build/1.0.408
  * https://travis-ci.org/isaachier/hunter/builds/354889983