### PR TITLE
add boost stacktrace as library to enable more powerful features

### DIFF
--- a/cmake/projects/Boost/atomic/hunter.cmake
+++ b/cmake/projects/Boost/atomic/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     atomic
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/chrono/hunter.cmake
+++ b/cmake/projects/Boost/chrono/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     chrono
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/context/hunter.cmake
+++ b/cmake/projects/Boost/context/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     context
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/contract/hunter.cmake
+++ b/cmake/projects/Boost/contract/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     contract
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/coroutine/hunter.cmake
+++ b/cmake/projects/Boost/coroutine/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     coroutine
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/date_time/hunter.cmake
+++ b/cmake/projects/Boost/date_time/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     date_time
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/exception/hunter.cmake
+++ b/cmake/projects/Boost/exception/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     exception
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/fiber/hunter.cmake
+++ b/cmake/projects/Boost/fiber/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     fiber
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/generate.sh
+++ b/cmake/projects/Boost/generate.sh
@@ -25,6 +25,7 @@ BOOST_LIBS="
     random
     regex
     serialization
+    stacktrace
     signals
     system
     test

--- a/cmake/projects/Boost/graph/hunter.cmake
+++ b/cmake/projects/Boost/graph/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/graph_parallel/hunter.cmake
+++ b/cmake/projects/Boost/graph_parallel/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph_parallel
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -312,4 +312,4 @@ endif()
 
 hunter_pick_scheme(DEFAULT url_sha1_boost)
 hunter_cacheable(Boost)
-hunter_download(PACKAGE_NAME Boost PACKAGE_INTERNAL_DEPS_ID "26")
+hunter_download(PACKAGE_NAME Boost PACKAGE_INTERNAL_DEPS_ID "27")

--- a/cmake/projects/Boost/hunter.cmake.in
+++ b/cmake/projects/Boost/hunter.cmake.in
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     boost_component
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/iostreams/hunter.cmake
+++ b/cmake/projects/Boost/iostreams/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     iostreams
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/locale/hunter.cmake
+++ b/cmake/projects/Boost/locale/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     locale
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/log/hunter.cmake
+++ b/cmake/projects/Boost/log/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     log
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/math/hunter.cmake
+++ b/cmake/projects/Boost/math/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     math
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/mpi/hunter.cmake
+++ b/cmake/projects/Boost/mpi/hunter.cmake
@@ -26,5 +26,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     mpi
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/program_options/hunter.cmake
+++ b/cmake/projects/Boost/program_options/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     program_options
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/python/hunter.cmake
+++ b/cmake/projects/Boost/python/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     python
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/random/hunter.cmake
+++ b/cmake/projects/Boost/random/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     random
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/regex/hunter.cmake
+++ b/cmake/projects/Boost/regex/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     regex
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/serialization/hunter.cmake
+++ b/cmake/projects/Boost/serialization/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     serialization
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/signals/hunter.cmake
+++ b/cmake/projects/Boost/signals/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     signals
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/stacktrace/hunter.cmake
+++ b/cmake/projects/Boost/stacktrace/hunter.cmake
@@ -17,6 +17,6 @@ hunter_download(
     PACKAGE_NAME
     Boost
     PACKAGE_COMPONENT
-    filesystem
+    stacktrace
     PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/system/hunter.cmake
+++ b/cmake/projects/Boost/system/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     system
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/test/hunter.cmake
+++ b/cmake/projects/Boost/test/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     test
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/thread/hunter.cmake
+++ b/cmake/projects/Boost/thread/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     thread
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/timer/hunter.cmake
+++ b/cmake/projects/Boost/timer/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     timer
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/cmake/projects/Boost/wave/hunter.cmake
+++ b/cmake/projects/Boost/wave/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     wave
-    PACKAGE_INTERNAL_DEPS_ID "26"
+    PACKAGE_INTERNAL_DEPS_ID "27"
 )

--- a/docs/packages/pkg/Boost.rst
+++ b/docs/packages/pkg/Boost.rst
@@ -29,6 +29,7 @@ Examples:
 - `Boost-filesystem <https://github.com/ruslo/hunter/blob/master/examples/Boost-filesystem/CMakeLists.txt>`__
 - `Boost-math <https://github.com/ruslo/hunter/blob/master/examples/Boost-math/CMakeLists.txt>`__
 - `Boost-contract <https://github.com/ruslo/hunter/blob/master/examples/Boost-contract/CMakeLists.txt>`__
+- `Boost-stacktrace <https://github.com/ruslo/hunter/blob/master/examples/Boost-stacktrace/CMakeLists.txt>`__
 
 List of components and availability (other libraries are header-only):
 

--- a/examples/Boost-stacktrace/CMakeLists.txt
+++ b/examples/Boost-stacktrace/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) 2013, Ruslan Baratov
+# All rights reserved.
+
+cmake_minimum_required(VERSION 3.0)
+
+# Emulate HunterGate:
+# * https://github.com/hunter-packages/gate
+include("../common.cmake")
+
+project(download-boost)
+
+hunter_add_package(Boost COMPONENTS system stacktrace)
+find_package(Boost CONFIG REQUIRED system stacktrace)
+
+add_executable(foo foo.cpp)
+target_link_libraries(foo PUBLIC Boost::system Boost::stacktrace)

--- a/examples/Boost-stacktrace/foo.cpp
+++ b/examples/Boost-stacktrace/foo.cpp
@@ -1,0 +1,4 @@
+#include <boost/stacktrace.hpp>
+
+int main() {
+}


### PR DESCRIPTION
By default Boost.Stacktrace is a header-only library.
But to get more detailed stacktraces it's possible to link boost as library
over this config flag "BOOST_STACKTRACE_LINK".