### PR TITLE
update spdlog to v0.16.3-p1

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -348,7 +348,7 @@ if(MSVC_VERSION LESS 1800)
     # for VS12 - version without support C++11
   hunter_config(spdlog VERSION 1.0.0-p0)
 else()
-  hunter_config(spdlog VERSION 0.13.0-p1)
+  hunter_config(spdlog VERSION 0.16.3-p1)
 endif()
 hunter_config(stb VERSION 0.0.1)
 hunter_config(szip VERSION 2.1.0-p1)

--- a/cmake/projects/spdlog/hunter.cmake
+++ b/cmake/projects/spdlog/hunter.cmake
@@ -5,6 +5,7 @@
 
 include(hunter_add_version)
 include(hunter_cacheable)
+include(hunter_cmake_args)
 include(hunter_download)
 include(hunter_pick_scheme)
 
@@ -23,22 +24,11 @@ hunter_add_version(
     PACKAGE_NAME
     spdlog
     VERSION
-    "0.13.0-p0"
+    "0.11.0-p0"
     URL
-    "https://github.com/hunter-packages/spdlog/archive/v0.13.0-p0.tar.gz"
+    "https://github.com/hunter-packages/spdlog/archive/v0.11.0-p0.tar.gz"
     SHA1
-    b34b92075423d9da196daefe796316393a0fd593
-)
-
-hunter_add_version(
-    PACKAGE_NAME
-    spdlog
-    VERSION
-    "0.13.0-p1"
-    URL
-    "https://github.com/hunter-packages/spdlog/archive/v0.13.0-p1.tar.gz"
-    SHA1
-    edf9ba15852b181e16e1fe323878d8281941b376
+    199c1a19bcdd6fc75faa61263a267805c05e4060
 )
 
 hunter_add_version(
@@ -56,11 +46,39 @@ hunter_add_version(
     PACKAGE_NAME
     spdlog
     VERSION
-    "0.11.0-p0"
+    "0.13.0-p0"
     URL
-    "https://github.com/hunter-packages/spdlog/archive/v0.11.0-p0.tar.gz"
+    "https://github.com/hunter-packages/spdlog/archive/v0.13.0-p0.tar.gz"
     SHA1
-    199c1a19bcdd6fc75faa61263a267805c05e4060
+    b34b92075423d9da196daefe796316393a0fd593
+)
+  
+hunter_add_version(
+    PACKAGE_NAME
+    spdlog
+    VERSION
+    "0.13.0-p1"
+    URL
+    "https://github.com/hunter-packages/spdlog/archive/v0.13.0-p1.tar.gz"
+    SHA1
+    edf9ba15852b181e16e1fe323878d8281941b376
+) 
+
+hunter_add_version(
+    PACKAGE_NAME
+    spdlog
+    VERSION
+    "0.16.3-p1"
+    URL
+    "https://github.com/hunter-packages/spdlog/archive/v0.16.3-p1.tar.gz"
+    SHA1
+    1400ca456ad7c5ba89491f0dd3cd8935a16fe65c
+)  
+
+hunter_cmake_args(
+    spdlog
+    CMAKE_ARGS
+        SPDLOG_EXTERNAL_TOOLCHAIN=ON # tell spdlog not to modify cxxflags
 )
 
 hunter_pick_scheme(DEFAULT url_sha1_cmake)


### PR DESCRIPTION
* I've tested this package remotely and have excluded all broken builds.
  Here is the links to the Travis/AppVeyor with status "All passed":

  + https://ci.appveyor.com/project/headupinclouds/hunter-8w0rs/build/1.0.68
  + https://travis-ci.org/headupinclouds/hunter/builds/373979866

NOTE: See pkg.spdlog update here https://github.com/ingenue/hunter/pull/239