### PR TITLE
Don't clobber LD_LIBRARY_PATH for autotools projects

### DIFF
--- a/cmake/modules/hunter_autotools_project.cmake
+++ b/cmake/modules/hunter_autotools_project.cmake
@@ -111,7 +111,7 @@ function(hunter_autotools_project target_name)
   set(default_path "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin")
   set(shell_env_path "PATH=${PARAM_GLOBAL_INSTALL_DIR}/bin:${default_path}")
 
-  set(shell_ld_path "LD_LIBRARY_PATH=${PARAM_GLOBAL_INSTALL_DIR}/lib")
+  set(shell_ld_path "LD_LIBRARY_PATH=${PARAM_GLOBAL_INSTALL_DIR}/lib:$ENV{LD_LIBRARY_PATH}")
 
   set(d1 "${PARAM_GLOBAL_INSTALL_DIR}/lib/pkgconfig")
   set(d2 "${PARAM_GLOBAL_INSTALL_DIR}/share/pkgconfig")


### PR DESCRIPTION
Prepend the global install dir to LD_LIBRARY_PATH, rather than
just overwriting an existing value. Without this patch, a toolchain
relying on LD_LIBRARY_PATH to find the C library will fail.