### PR TITLE
Upgrade protobuf-c

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -318,7 +318,7 @@ hunter_config(libpcre VERSION 8.41)
 hunter_config(poly2tri VERSION 1.0.0)
 hunter_config(polyclipping VERSION 4.8.8-p0) # for Assimp
 hunter_config(presentproto VERSION 1.0)
-hunter_config(protobuf-c VERSION 1.3.0-p0)
+hunter_config(protobuf-c VERSION 1.3.0-p1)
 hunter_config(pthread-stubs VERSION 0.3)
 hunter_config(pugixml VERSION 1.8.1)
 hunter_config(pybind11 VERSION 2.2.1)

--- a/cmake/projects/protobuf-c/hunter.cmake
+++ b/cmake/projects/protobuf-c/hunter.cmake
@@ -12,6 +12,12 @@ hunter_add_version(
     URL "https://github.com/hunter-packages/protobuf-c/archive/v1.3.0-p0.tar.gz"
     SHA1 "e106e376b95650521e860642cd660e503a2d4f5c")
 
+hunter_add_version(
+    PACKAGE_NAME protobuf-c
+    VERSION "1.3.0-p1"
+    URL "https://github.com/hunter-packages/protobuf-c/archive/v1.3.0-p1.tar.gz"
+    SHA1 "d93fc3f0f422f62a5c0454981f73a5acdbf8b078")
+
 hunter_cmake_args(protobuf-c CMAKE_ARGS BUILD_TESTING=OFF)
 
 hunter_pick_scheme(DEFAULT url_sha1_cmake)


### PR DESCRIPTION
* I've tested this package remotely and have excluded all broken builds.
  Here is the links to the Travis/AppVeyor with status "All passed":

  * https://ci.appveyor.com/project/isaachier/hunter/build/1.0.491
  * https://travis-ci.org/isaachier/hunter/builds/379499609

* This update will break few old toolchains.
  They are excluded in this pull request: https://github.com/ingenue/hunter/pull/250

---
<!--- END -->

<!--- Use this part of template for other type of changes. Remove the rest. -->
<!--- BEGIN -->

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes|No]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes|No]**
* My change will work with CMake 3.0 (minimum requirement for Hunter). **[Yes|No]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes|No]**

---
<!--- END -->
