### PR TITLE
Updated tacopie to version 3.2.0

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -448,6 +448,6 @@ if(ANDROID)
 endif()
 
 hunter_config(zookeeper VERSION 3.4.9-p2)
-hunter_config(tacopie VERSION 2.4.0-h1)
+hunter_config(tacopie VERSION 3.2.0-h1)
 hunter_config(cpp_redis VERSION 3.5.0-h1)
 hunter_config(IF97 VERSION 2.1.2)

--- a/cmake/projects/tacopie/hunter.cmake
+++ b/cmake/projects/tacopie/hunter.cmake
@@ -20,6 +20,17 @@ hunter_add_version(
     5b326dd4e4792e63d9261682205f32944719bed0
 )
 
+hunter_add_version(
+    PACKAGE_NAME
+    tacopie
+    VERSION
+    "3.2.0-h1"
+    URL
+    "https://github.com/hunter-packages/tacopie/archive/3.2.0-h1.tar.gz"
+    SHA1
+    04a8953bf69f1fa26b68dd76df4b4baea291ab34
+)
+
 # Pick a download scheme
 hunter_pick_scheme(DEFAULT url_sha1_cmake) # use scheme for cmake projects
 


### PR DESCRIPTION
* I've tested this package remotely and have excluded all broken builds.
  Here is the links to the Travis/AppVeyor with status "All passed":

  * https://ci.appveyor.com/project/szatan/hunter/build/1.0.9
  * https://travis-ci.org/szatan/hunter/builds/382532942

@ruslo Testing against toolchains enabled in https://github.com/ingenue/hunter/tree/pkg.tacopie
