### PR TITLE
docs: boost-components same cmake version

### DIFF
--- a/docs/quick-start/boost-components.rst
+++ b/docs/quick-start/boost-components.rst
@@ -68,7 +68,7 @@ Summarize:
 .. code-block:: cmake
   :emphasize-lines: 5-6, 11
 
-  cmake_minimum_required(VERSION 3.0)
+  cmake_minimum_required(VERSION 3.2)
 
   include("cmake/HunterGate.cmake")
   HunterGate(


### PR DESCRIPTION
Use the same cmake version in step by step explanation and the summary