### PR TITLE
OpenBLAS: Fix host Android compiles

### DIFF
--- a/cmake/projects/OpenBLAS/hunter.cmake
+++ b/cmake/projects/OpenBLAS/hunter.cmake
@@ -40,7 +40,7 @@ endif()
 hunter_cacheable(OpenBLAS)
 hunter_download(
     PACKAGE_NAME OpenBLAS
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/cmake/openblas/OpenBLASConfig.cmake"
 )

--- a/cmake/projects/OpenBLAS/schemes/OpenBLAS.cmake.in
+++ b/cmake/projects/OpenBLAS/schemes/OpenBLAS.cmake.in
@@ -55,7 +55,7 @@ endif()
 set(compiler_arg "@CMAKE_C_COMPILER@")
 
 
-if(CMAKE_CROSSCOMPILING)
+if(CMAKE_CROSSCOMPILING OR ANDROID)
   # Tells OpenBLAS where to find host CC (HOSTCC=)
   # and not to run tests (CROSS=1)
   # and not to use fortran (NOFORTRAN=1)


### PR DESCRIPTION
This is required as OpenBLAS upstream doesn't support automatically configured arm compiles, so we workaround this by manually setting target and telling it to avoid tests (CROSS=1), which is the same as when we do an actual cross-compile.
This will be fixed in OpenBLAS 0.3.0 but I haven't updated the CMake config for it yet.

Very small update that doesn't affect any targeted builds.