### PR TITLE
Fix setting of CXXFLAGS in hunter_get_build_flags (Affect all autotools pkg builds)

### DIFF
--- a/cmake/modules/hunter_get_build_flags.cmake
+++ b/cmake/modules/hunter_get_build_flags.cmake
@@ -129,7 +129,7 @@ function(hunter_get_build_flags)
     )
     string(STRIP "${cxxflags}" cxxflags)
     hunter_status_debug("  CXXFLAGS=${cxxflags}")
-    set(${PARAM_OUT_CXXFLAGS} ${cflags} PARENT_SCOPE)
+    set(${PARAM_OUT_CXXFLAGS} ${cxxflags} PARENT_SCOPE)
   endif()
 
   if(has_out_ldflags)

--- a/cmake/projects/gstreamer/hunter.cmake
+++ b/cmake/projects/gstreamer/hunter.cmake
@@ -35,7 +35,7 @@ hunter_cmake_args(
 hunter_cacheable(gstreamer)
 hunter_download(
     PACKAGE_NAME gstreamer
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/gstreamer-1.0/libgstcoreelements.la"
     "lib/gstreamer-1.0/libgstcoretracers.la"

--- a/cmake/projects/xau/hunter.cmake
+++ b/cmake/projects/xau/hunter.cmake
@@ -37,6 +37,6 @@ hunter_cmake_args(
 hunter_cacheable(xau)
 hunter_download(
     PACKAGE_NAME xau
-    PACKAGE_INTERNAL_DEPS_ID "4"
+    PACKAGE_INTERNAL_DEPS_ID "5"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/libXau.la;lib/pkgconfig/xau.pc"
 )


### PR DESCRIPTION
There is a typo in `hunter_get_build_flags` modul. `CXXFLAGS` was set with `CFLAGS` instead of `CXXFLAGS`. This affect all autotools builds.