### PR TITLE
Proper parse of linker flags in pkg config files in pkgconfig_export_target

### DIFF
--- a/cmake/modules/hunter_pkgconfig_export_target.cmake
+++ b/cmake/modules/hunter_pkgconfig_export_target.cmake
@@ -71,7 +71,9 @@ function(hunter_pkgconfig_export_target PKG_CONFIG_MODULE)
       has_ldflags_other
   )
   if(has_ldflags_other)
-    list(APPEND link_libs ${${PKG_CONFIG_MODULE}_LDFLAGS_OTHER})
+    # turn "-framework;A;-framework;B" into "-framework A;-framework B"
+    string(REPLACE "-framework;" "-framework " ldflags_other "${${PKG_CONFIG_MODULE}_LDFLAGS_OTHER}")
+    list(APPEND link_libs ${ldflags_other})
   endif()
 
   # No need to treat the pkg-config module's _LIBRARY_DIRS and _LIBRARIES

--- a/cmake/modules/hunter_pkgconfig_export_target.cmake
+++ b/cmake/modules/hunter_pkgconfig_export_target.cmake
@@ -33,12 +33,7 @@ function(hunter_pkgconfig_export_target PKG_CONFIG_MODULE)
   hunter_status_debug(
       "PKG_CONFIG_MODULE ${PKG_CONFIG_MODULE} INCLUDE_DIRS: ${${PKG_CONFIG_MODULE}_INCLUDE_DIRS}"
   )
-  string(COMPARE NOTEQUAL
-      "${${PKG_CONFIG_MODULE}_INCLUDE_DIRS}"
-      ""
-      has_include_dirs
-  )
-  if(has_include_dirs)
+  if(NOT "${${PKG_CONFIG_MODULE}_INCLUDE_DIRS}" STREQUAL "")
     set_target_properties("${target_name}"
         PROPERTIES
           INTERFACE_INCLUDE_DIRECTORIES
@@ -53,24 +48,14 @@ function(hunter_pkgconfig_export_target PKG_CONFIG_MODULE)
   hunter_status_debug(
       "PKG_CONFIG_MODULE ${PKG_CONFIG_MODULE} LDFLAGS: ${${PKG_CONFIG_MODULE}_LDFLAGS}"
   )
-  string(COMPARE NOTEQUAL
-      "${${PKG_CONFIG_MODULE}_LDFLAGS}"
-      ""
-      has_ldflags
-  )
-  if(has_ldflags)
+  if(NOT "${${PKG_CONFIG_MODULE}_LDFLAGS}" STREQUAL "")
     list(APPEND link_libs ${${PKG_CONFIG_MODULE}_LDFLAGS})
   endif()
 
   hunter_status_debug(
       "PKG_CONFIG_MODULE ${PKG_CONFIG_MODULE} LDFLAGS_OTHER: ${${PKG_CONFIG_MODULE}_LDFLAGS_OTHER}"
   )
-  string(COMPARE NOTEQUAL
-      "${${PKG_CONFIG_MODULE}_LDFLAGS_OTHER}"
-      ""
-      has_ldflags_other
-  )
-  if(has_ldflags_other)
+  if(NOT "${${PKG_CONFIG_MODULE}_LDFLAGS_OTHER}" STREQUAL "")
     # turn "-framework;A;-framework;B" into "-framework A;-framework B"
     string(REPLACE "-framework;" "-framework " ldflags_other "${${PKG_CONFIG_MODULE}_LDFLAGS_OTHER}")
     list(APPEND link_libs ${ldflags_other})
@@ -78,12 +63,7 @@ function(hunter_pkgconfig_export_target PKG_CONFIG_MODULE)
 
   # No need to treat the pkg-config module's _LIBRARY_DIRS and _LIBRARIES
   # as they are already included in LD_FLAGS
-  string(COMPARE NOTEQUAL
-      "${link_libs}"
-      ""
-      has_link_libs
-  )
-  if(has_link_libs)
+  if(NOT "${link_libs}" STREQUAL "")
     set_target_properties("${target_name}"
         PROPERTIES
           INTERFACE_LINK_LIBRARIES
@@ -98,32 +78,18 @@ function(hunter_pkgconfig_export_target PKG_CONFIG_MODULE)
   hunter_status_debug(
       "PKG_CONFIG_MODULE ${PKG_CONFIG_MODULE} CFLAGS: ${${PKG_CONFIG_MODULE}_CFLAGS}"
   )
-  string(COMPARE NOTEQUAL
-      "${${PKG_CONFIG_MODULE}_CFLAGS}"
-      ""
-      has_cflags)
-  if(has_cflags)
+  if(NOT "${${PKG_CONFIG_MODULE}_CFLAGS}" STREQUAL "")
     list(APPEND compile_opts ${${PKG_CONFIG_MODULE}_CFLAGS})
   endif()
 
   hunter_status_debug(
       "PKG_CONFIG_MODULE ${PKG_CONFIG_MODULE} CFLAGS_OTHER: ${${PKG_CONFIG_MODULE}_CFLAGS_OTHER}"
   )
-  string(COMPARE NOTEQUAL
-      "${${PKG_CONFIG_MODULE}_CFLAGS_OTHER}"
-      ""
-      has_cflags_other
-  )
-  if(has_cflags_other)
+  if(NOT "${${PKG_CONFIG_MODULE}_CFLAGS_OTHER}" STREQUAL "")
     list(APPEND compile_opts ${${PKG_CONFIG_MODULE}_CFLAGS_OTHER})
   endif()
 
-  string(COMPARE NOTEQUAL
-     "${compile_opts}"
-     ""
-     has_compile_opts
-  )
-  if(has_compile_opts)
+  if(NOT "${compile_opts}" STREQUAL "")
       set_target_properties("${target_name}"
           PROPERTIES
             INTERFACE_COMPILE_OPTIONS

--- a/cmake/projects/x11/hunter.cmake
+++ b/cmake/projects/x11/hunter.cmake
@@ -41,7 +41,7 @@ hunter_cmake_args(
 hunter_cacheable(x11)
 hunter_download(
     PACKAGE_NAME x11
-    PACKAGE_INTERNAL_DEPS_ID "4"
+    PACKAGE_INTERNAL_DEPS_ID "5"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libX11-xcb.la"
     "lib/libX11.la"

--- a/cmake/projects/x264/hunter.cmake
+++ b/cmake/projects/x264/hunter.cmake
@@ -25,6 +25,7 @@ hunter_cmake_args(x264 CMAKE_ARGS PKGCONFIG_EXPORT_TARGETS=x264)
 hunter_cacheable(x264)
 hunter_download(
     PACKAGE_NAME x264
+    PACKAGE_INTERNAL_DEPS_ID "1"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/pkgconfig/x264.pc"
 )
 

--- a/cmake/projects/xcb/hunter.cmake
+++ b/cmake/projects/xcb/hunter.cmake
@@ -63,6 +63,6 @@ hunter_pick_scheme(DEFAULT xcb)
 hunter_cacheable(xcb)
 hunter_download(
     PACKAGE_NAME xcb
-    PACKAGE_INTERNAL_DEPS_ID "3"
+    PACKAGE_INTERNAL_DEPS_ID "4"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "${_xcb_text_files}"
 )


### PR DESCRIPTION
If a project provide on MacOSx following pkgconfig `*.pc` file:

 ```
...
 Libs: -L${libdir} -lfoo-apple -lbar -lpthread  -framework CoreAudio -framework CoreFoundation
 ...
```
Then `hunter_pkgconfig_export_target.cmake` is set `INTERFACE_LINK_LIBRARIES` in cmake as following:

` -Lfoo/bar;-lfoo-apple;-lbar;-lpthread;-framework;CoreAudio;-framework;CoreFoundation`

The linker get following parameters:

` ... -Lfoo/bar -lfoo-apple -lbar -lpthread -framework -lCoreAudio -lCoreFoundation`

Linker fails with: "Cannot find CoreAudio library"


This request set `INTERFACE_LINK_LIBRARIES` with following line:

` -Lfoo/bar;-lfoo-apple;-lbar;-lpthread;-framework CoreAudio;-framework CoreFoundation`

The linker gets following parameters:

` ... -Lfoo/bar -lfoo-apple -lbar -lpthread -framework CoreAudio -framework CoreFoundation`

Now it works :-)

