### PR TITLE
OpenBLAS: Don't use CMake on 0.3.0

### DIFF
--- a/cmake/projects/OpenBLAS/hunter.cmake
+++ b/cmake/projects/OpenBLAS/hunter.cmake
@@ -55,7 +55,7 @@ hunter_add_version(
 )
 
 hunter_configuration_types(OpenBLAS CONFIGURATION_TYPES Release)
-if(HUNTER_OpenBLAS_VERSION VERSION_LESS 0.3.0)
+if(HUNTER_OpenBLAS_VERSION VERSION_LESS 0.3.1)
   hunter_pick_scheme(DEFAULT OpenBLAS)
   set(
       _openblas_unrelocatable_text_files


### PR DESCRIPTION
The CMake build seems to provide an inferior build that causes an infinite loop, so fallback to normal build on 0.3.0.