### PR TITLE
ZLIB: added zlib.pc to PACKAGE_UNRELOCATABLE_TEXT_FILES for glib et al.

### DIFF
--- a/cmake/projects/ZLIB/hunter.cmake
+++ b/cmake/projects/ZLIB/hunter.cmake
@@ -54,4 +54,9 @@ hunter_add_version(
 
 hunter_pick_scheme(DEFAULT url_sha1_cmake)
 hunter_cacheable(ZLIB)
-hunter_download(PACKAGE_NAME ZLIB)
+hunter_download(PACKAGE_NAME ZLIB 
+    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_UNRELOCATABLE_TEXT_FILES 
+    "share/pkgconfig/zlib.pc"
+)
+


### PR DESCRIPTION
While investigating an External Build Failed for glib in a project that also uses zlib from hunter, I found that the installed zlib.pc contained paths pointing into Hunter/_Base/xxxxxxx/xxxxxxx/xxxxxxx/Build/ZLIB/ instead of Hunter/_Base/526ade5/68509e5/555125f/Install.

Setting PACKAGE_UNRELOCATABLE_TEXT_FILES for zlib.pc solved the issue and is likely to be required for other hunterized packages using autotools (ie. depending on zlib via pkg-config) instead of cmake.

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.0 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

* I am new to this project and its workflow and ask for feedback if doing things differently next time would make things easier for you. **[YES]**