### PR TITLE
inital llvm and cmake 3.8 support

### DIFF
--- a/cmake/projects/Clang/hunter.cmake
+++ b/cmake/projects/Clang/hunter.cmake
@@ -7,6 +7,9 @@ include(hunter_add_version)
 include(hunter_download)
 include(hunter_pick_scheme)
 
+
+
+
 hunter_add_version(
     PACKAGE_NAME
     Clang
@@ -18,6 +21,16 @@ hunter_add_version(
     cc2e74c852f57c946a4337812c73ce1bc97d639f
 )
 
+hunter_add_version(
+        PACKAGE_NAME
+        Clang
+        VERSION
+        "3.8.0"
+        URL
+        "http://releases.llvm.org/3.8.0/cfe-3.8.0.src.tar.xz"
+        SHA1
+        2230ef962f2df3c13ec93f5b04b0e3cdff94b2ce
+)
 hunter_add_version(
     PACKAGE_NAME
     Clang

--- a/cmake/projects/ClangToolsExtra/hunter.cmake
+++ b/cmake/projects/ClangToolsExtra/hunter.cmake
@@ -17,7 +17,16 @@ hunter_add_version(
     SHA1
     414ccbadc4ba0658b34421a3855784af4e767796
 )
-
+hunter_add_version(
+        PACKAGE_NAME
+        ClangToolsExtra
+        VERSION
+        "3.8.0"
+        URL
+        "http://releases.llvm.org/3.8.0/clang-tools-extra-3.8.0.src.tar.xz"
+        SHA1
+        a99d8b6fc5e593c4671424b327779318a1856acf
+)
 hunter_add_version(
     PACKAGE_NAME
     ClangToolsExtra

--- a/cmake/projects/LLVM/hunter.cmake
+++ b/cmake/projects/LLVM/hunter.cmake
@@ -34,6 +34,17 @@ hunter_add_version(
 )
 
 hunter_add_version(
+        PACKAGE_NAME
+        LLVM
+        VERSION
+        "3.8.0"
+        URL
+        "http://www.llvm.org/releases/3.8.0/llvm-3.8.0.src.tar.xz"
+        SHA1
+        723ac918979255706434a05f5af34b71c49c9971
+)
+
+hunter_add_version(
     PACKAGE_NAME
     LLVM
     VERSION

--- a/cmake/projects/LLVMCompilerRT/hunter.cmake
+++ b/cmake/projects/LLVMCompilerRT/hunter.cmake
@@ -17,7 +17,16 @@ hunter_add_version(
     SHA1
     561c29f1595c29f1d083567a7e669fec30cdfa44
 )
-
+hunter_add_version(
+        PACKAGE_NAME
+        LLVMCompilerRT
+        VERSION
+        "3.8.0"
+        URL
+        "http://releases.llvm.org/3.8.0/compiler-rt-3.8.0.src.tar.xz"
+        SHA1
+        480ea09e369dac6de1f3759b27fa19417b26b69e
+)
 hunter_add_version(
     PACKAGE_NAME
     LLVMCompilerRT


### PR DESCRIPTION
This is an initial pr to address 3.8 in
https://github.com/ruslo/hunter/issues/1522
I did not fork/'hunterize' the packages because I would like to raise the question in 
https://github.com/ruslo/hunter/issues/1528
