### PR TITLE
Fix Boost 1.68.0 build on MSVC.

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -33,14 +33,11 @@ hunter_default_version(Avahi VERSION 0.6.31)
 hunter_default_version(BZip2 VERSION 1.0.6-p3)
 hunter_default_version(Beast VERSION 1.0.0-b84-hunter-0)
 
-if(MSVC)
-  # https://github.com/boostorg/build/issues/299
-  hunter_default_version(Boost VERSION 1.66.0-p0)
-elseif(MINGW)
+if(MINGW)
   # https://github.com/boostorg/build/issues/301
   hunter_default_version(Boost VERSION 1.64.0)
 else()
-  hunter_default_version(Boost VERSION 1.68.0-p0)
+  hunter_default_version(Boost VERSION 1.68.0-p1)
 endif()
 
 hunter_default_version(BoostCompute VERSION 0.5-p0)

--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -104,6 +104,17 @@ hunter_add_version(
     3af972569d4b685145442445e51b3fcace342b31
 )
 
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.68.0-p1"
+    URL
+    "https://github.com/nxxm/boost/archive/v1.68.0-p1.tar.gz"
+    SHA1
+    48ba32d027334de6bead48ff20b17695cb54be5d 
+)
+
 # up until 1.63 sourcefourge was used
 set(_hunter_boost_base_url "https://downloads.sourceforge.net/project/boost/boost/")
 hunter_add_version(

--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -110,9 +110,9 @@ hunter_add_version(
     VERSION
     "1.68.0-p1"
     URL
-    "https://github.com/nxxm/boost/archive/v1.68.0-p1.tar.gz"
+    "https://github.com/hunter-packages/boost/archive/v1.68.0-p1.tar.gz"
     SHA1
-    48ba32d027334de6bead48ff20b17695cb54be5d 
+    0bb10b0a0fdc196646c87e0143c0290baa32357d 
 )
 
 # up until 1.63 sourcefourge was used


### PR DESCRIPTION
Dear @ruslo,

As mentioned in https://github.com/boostorg/build/issues/299#issuecomment-417914915 I've integrated the patch which is in boostorg/build develop branch in a 1.68.0-p1 Boost package.

* boost-1.68.0-p1 is here : https://github.com/hunter-packages/boost/pull/5.

I got my own CI with projects depending on Boost based on this version of Hunter working (VS2017 15.8.2, clang 6.0.1 macOS & gcc-7 ubuntu 16.04).

To that I've let the travis-ci build running : https://travis-ci.com/nxxm/hunter/builds/83574643 

However I cannot get the appveyor build to start, it believes it's an MSBuild project, do you have any pointer on how I could set it to build ? Should I fork ingenue/hunter ?

Cheers,