### PR TITLE
graph: exclude some utility modules from overview graph

### DIFF
--- a/maintenance/graphs/modules2dot.sh
+++ b/maintenance/graphs/modules2dot.sh
@@ -19,11 +19,16 @@ PNG_FILE="${PNG_DIR}/${dot_basename}.png"
 excluded_modules=(
 	hunter_status_print
 	hunter_status_debug
+	hunter_print_cmd
 	hunter_user_error
 	hunter_internal_error
 	hunter_fatal_error
 	hunter_wiki
 	hunter_assert_not_empty_string
+	hunter_assert_empty_string
+	hunter_lock_directory
+	hunter_make_directory
+	hunter_sleep_before_download
 )
 
 


### PR DESCRIPTION
<!--- Use this part of template for other type of changes. Remove the rest. -->
<!--- BEGIN -->

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[No]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

---
<!--- END -->

resulting graph for current master
![modules](https://user-images.githubusercontent.com/9076163/46288691-e0a50200-c586-11e8-8441-8802b18bced3.png)

I could exclude some hunter_download or hunter_cache modules for even more visibility, but I wasn't sure which ones