### PR TITLE
Adding support for QNX

### DIFF
--- a/cmake/projects/Boost/atomic/hunter.cmake
+++ b/cmake/projects/Boost/atomic/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     atomic
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/chrono/hunter.cmake
+++ b/cmake/projects/Boost/chrono/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     chrono
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/context/hunter.cmake
+++ b/cmake/projects/Boost/context/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     context
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/contract/hunter.cmake
+++ b/cmake/projects/Boost/contract/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     contract
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/coroutine/hunter.cmake
+++ b/cmake/projects/Boost/coroutine/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     coroutine
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/date_time/hunter.cmake
+++ b/cmake/projects/Boost/date_time/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     date_time
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/exception/hunter.cmake
+++ b/cmake/projects/Boost/exception/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     exception
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/fiber/hunter.cmake
+++ b/cmake/projects/Boost/fiber/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     fiber
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/filesystem/hunter.cmake
+++ b/cmake/projects/Boost/filesystem/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     filesystem
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/graph/hunter.cmake
+++ b/cmake/projects/Boost/graph/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/graph_parallel/hunter.cmake
+++ b/cmake/projects/Boost/graph_parallel/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph_parallel
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -367,4 +367,4 @@ endif()
 
 hunter_pick_scheme(DEFAULT url_sha1_boost)
 hunter_cacheable(Boost)
-hunter_download(PACKAGE_NAME Boost PACKAGE_INTERNAL_DEPS_ID "34")
+hunter_download(PACKAGE_NAME Boost PACKAGE_INTERNAL_DEPS_ID "35")

--- a/cmake/projects/Boost/hunter.cmake.in
+++ b/cmake/projects/Boost/hunter.cmake.in
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     boost_component
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/iostreams/hunter.cmake
+++ b/cmake/projects/Boost/iostreams/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     iostreams
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/locale/hunter.cmake
+++ b/cmake/projects/Boost/locale/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     locale
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/log/hunter.cmake
+++ b/cmake/projects/Boost/log/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     log
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/math/hunter.cmake
+++ b/cmake/projects/Boost/math/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     math
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/mpi/hunter.cmake
+++ b/cmake/projects/Boost/mpi/hunter.cmake
@@ -26,5 +26,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     mpi
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/program_options/hunter.cmake
+++ b/cmake/projects/Boost/program_options/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     program_options
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/python/hunter.cmake
+++ b/cmake/projects/Boost/python/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     python
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/random/hunter.cmake
+++ b/cmake/projects/Boost/random/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     random
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/regex/hunter.cmake
+++ b/cmake/projects/Boost/regex/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     regex
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
@@ -69,6 +69,9 @@ elseif("@APPLE@")
   # Using CMAKE_AR on OSX leads to error (b2 use 'libtool'):
   # * https://travis-ci.org/ingenue/hunter/jobs/204617507
   set(use_cmake_archiver FALSE)
+elseif("@QNX@")
+  set(toolset_name "qcc")
+  set(toolset_version "")
 elseif("@CMAKE_COMPILER_IS_GNUCXX@")
   set(toolset_name "gcc")
   set(toolset_version "")

--- a/cmake/projects/Boost/serialization/hunter.cmake
+++ b/cmake/projects/Boost/serialization/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     serialization
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/signals/hunter.cmake
+++ b/cmake/projects/Boost/signals/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     signals
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/stacktrace/hunter.cmake
+++ b/cmake/projects/Boost/stacktrace/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     stacktrace
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/system/hunter.cmake
+++ b/cmake/projects/Boost/system/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     system
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/test/hunter.cmake
+++ b/cmake/projects/Boost/test/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     test
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/thread/hunter.cmake
+++ b/cmake/projects/Boost/thread/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     thread
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/timer/hunter.cmake
+++ b/cmake/projects/Boost/timer/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     timer
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )

--- a/cmake/projects/Boost/wave/hunter.cmake
+++ b/cmake/projects/Boost/wave/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     wave
-    PACKAGE_INTERNAL_DEPS_ID "34"
+    PACKAGE_INTERNAL_DEPS_ID "35"
 )


### PR DESCRIPTION
While building Boost for QNX appropriate toolset needs to be set (qcc)
