### PR TITLE
Add link to CLI11 from commandline tools page

### DIFF
--- a/docs/packages/commandline.rst
+++ b/docs/packages/commandline.rst
@@ -8,3 +8,4 @@ Commandline Tools
 
  - :ref:`pkg.gflags` - contains a C++ library that implements commandline flags processing
  - :ref:`pkg.cxxopts` - Lightweight C++ command line option parser
+ - :ref:`pkg.CLI11` - command line parser for C++11 and beyond that provides a rich feature set with a simple and intuitive interface


### PR DESCRIPTION
CLI11, a command-line argument parser, probably belongs under the
commandline tools contents page along with similar tools.

Note that I am committing this on a Windows machine, and am unable to
generate the documentation to test the output. I've copied the existing
examples and modified it for CLI11.

In response to #1611.

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). Yes
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). Yes
* My change will work with CMake 3.2 (minimum requirement for Hunter). Yes
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. Yes
