### PR TITLE
documentation: include hunter_cmake_args

### DIFF
--- a/docs/creating-new/create/cmake.rst
+++ b/docs/creating-new/create/cmake.rst
@@ -315,8 +315,8 @@ disable those. If such an option is not disabled by default use
 .. code-block:: cmake
   :emphasize-lines: 3, 6-8
 
-  # bottom of cmake/projects/Foo/hunter.cmake
-
+  include(hunter_cmake_args)
+  # bottom of cmake/projects/hunter_box_1/hunter.cmake
   hunter_cmake_args(
       Foo
       CMAKE_ARGS


### PR DESCRIPTION
<!--- Use this part of template for other type of changes. Remove the rest. -->
<!--- BEGIN -->

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **Yes**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **Yes**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **Yes**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **Yes**

---
<!--- END -->
In the documentation for adding a new package, the section "CMake options" doesn't mention that hunter_cmake_args must be included. I propose to fix this...