### PR TITLE
[LodePNG] Fix docs

### DIFF
--- a/docs/packages/pkg/LodePNG.rst
+++ b/docs/packages/pkg/LodePNG.rst
@@ -11,7 +11,7 @@ LodePNG
 
 -  `Official <https://github.com/lvandeve/lodepng>`__
 -  `Hunterized <https://github.com/hunter-packages/lodepng>`__
--  `Example <https://github.com/ruslo/hunter/blob/master/examples/foo/CMakeLists.txt>`__
+-  `Example <https://github.com/ruslo/hunter/blob/master/examples/LodePNG/CMakeLists.txt>`__
 -  Added by `Brad Kotsopoulos <https://github.com/bkotzz>`__ (`pr-1636 <https://github.com/ruslo/hunter/pull/1636>`__)
 
 .. literalinclude:: /../examples/LodePNG/CMakeLists.txt


### PR DESCRIPTION
I made a mistake on the previous PR in the docs. Setting the examples link to https://github.com/ruslo/hunter/blob/master/examples/LodePNG/CMakeLists.txt.