### PR TITLE
Added REQUESTED_PYTHON_VERSION CMAKE_ARGS option for Boost

### DIFF
--- a/cmake/projects/Boost/atomic/hunter.cmake
+++ b/cmake/projects/Boost/atomic/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     atomic
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/chrono/hunter.cmake
+++ b/cmake/projects/Boost/chrono/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     chrono
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/context/hunter.cmake
+++ b/cmake/projects/Boost/context/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     context
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/contract/hunter.cmake
+++ b/cmake/projects/Boost/contract/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     contract
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/coroutine/hunter.cmake
+++ b/cmake/projects/Boost/coroutine/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     coroutine
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/date_time/hunter.cmake
+++ b/cmake/projects/Boost/date_time/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     date_time
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/exception/hunter.cmake
+++ b/cmake/projects/Boost/exception/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     exception
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/fiber/hunter.cmake
+++ b/cmake/projects/Boost/fiber/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     fiber
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/filesystem/hunter.cmake
+++ b/cmake/projects/Boost/filesystem/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     filesystem
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/graph/hunter.cmake
+++ b/cmake/projects/Boost/graph/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/graph_parallel/hunter.cmake
+++ b/cmake/projects/Boost/graph_parallel/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph_parallel
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -112,7 +112,7 @@ hunter_add_version(
     URL
     "https://github.com/hunter-packages/boost/archive/v1.68.0-p1.tar.gz"
     SHA1
-    0bb10b0a0fdc196646c87e0143c0290baa32357d 
+    0bb10b0a0fdc196646c87e0143c0290baa32357d
 )
 
 # up until 1.63 sourcefourge was used
@@ -367,4 +367,4 @@ endif()
 
 hunter_pick_scheme(DEFAULT url_sha1_boost)
 hunter_cacheable(Boost)
-hunter_download(PACKAGE_NAME Boost PACKAGE_INTERNAL_DEPS_ID "36")
+hunter_download(PACKAGE_NAME Boost PACKAGE_INTERNAL_DEPS_ID "37")

--- a/cmake/projects/Boost/hunter.cmake.in
+++ b/cmake/projects/Boost/hunter.cmake.in
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     boost_component
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/iostreams/hunter.cmake
+++ b/cmake/projects/Boost/iostreams/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     iostreams
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/locale/hunter.cmake
+++ b/cmake/projects/Boost/locale/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     locale
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/log/hunter.cmake
+++ b/cmake/projects/Boost/log/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     log
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/math/hunter.cmake
+++ b/cmake/projects/Boost/math/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     math
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/mpi/hunter.cmake
+++ b/cmake/projects/Boost/mpi/hunter.cmake
@@ -26,5 +26,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     mpi
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/program_options/hunter.cmake
+++ b/cmake/projects/Boost/program_options/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     program_options
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/python/hunter.cmake
+++ b/cmake/projects/Boost/python/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     python
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/random/hunter.cmake
+++ b/cmake/projects/Boost/random/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     random
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/regex/hunter.cmake
+++ b/cmake/projects/Boost/regex/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     regex
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
@@ -24,6 +24,7 @@ include(hunter_status_print)
 include(hunter_assert_not_empty_string)
 include(hunter_user_error)
 include(hunter_parse_boost_config_macros)
+include(hunter_parse_cmake_args_for_keyword)
 
 hunter_status_debug("Scheme: url_sha1_boost_library")
 
@@ -194,6 +195,8 @@ else()
   set(link_opts link=shared)
 endif()
 
+# Modify Boost user jam file
+
 set(toolset_full_name ${toolset_name})
 string(COMPARE NOTEQUAL "${toolset_version}" "" has_toolset_version)
 if(has_toolset_version)
@@ -285,6 +288,52 @@ file(
     ";\n"
     "${using_mpi}\n"
 )
+
+# handle requested python version if such is specified
+hunter_parse_cmake_args_for_keyword(
+  CMAKE_ARGS "@HUNTER_Boost_CMAKE_ARGS@"
+  KEYWORD REQUESTED_PYTHON_VERSION
+  OUTPUT requested_python
+)
+
+# set up paths for python in boost.user.jam
+if(NOT requested_python STREQUAL "")
+  find_package(PythonInterp ${requested_python} EXACT QUIET)
+  if(NOT PYTHONINTERP_FOUND)
+    hunter_user_error("Python Interpreter for Python version ${requested_python} not found.")
+  endif()
+  set(python_executable ${PYTHON_EXECUTABLE})
+  execute_process(
+    COMMAND "${python_executable}" -c "import os.path, sysconfig; info = sysconfig.get_paths(); print(info['include'])"
+    RESULT_VARIABLE python_process
+    OUTPUT_VARIABLE python_include_directory
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if(NOT python_process EQUAL 0)
+    hunter_user_error("Python include directory for Python version ${requested_python} not found.")
+  endif()
+  if(NOT EXISTS "${python_include_directory}")
+    hunter_internal_error("Directory not found: ${python_include_directory}")
+  endif()
+  execute_process(
+    COMMAND "${python_executable}" -c "import os.path, sysconfig; info = sysconfig.get_paths(); print(os.path.dirname(info['stdlib']))"
+    RESULT_VARIABLE python_process
+    OUTPUT_VARIABLE python_library_directory
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if(NOT python_process EQUAL 0)
+    hunter_user_error("Python runtime library directory for Python version ${requested_python} not found.")
+  endif()
+  if(NOT EXISTS "${python_library_directory}")
+    hunter_internal_error("Directory not found: ${python_library_directory}")
+  endif()
+  file(
+    APPEND ${boost_user_jam}
+    "using python  : ${requested_python} : \"${python_executable}\" : \"${python_include_directory}\" : \"${python_library_directory}\" ;\n"
+  )
+endif()
+
+# Handle ./b2 build options
 
 list(APPEND build_opts ${b2_component_opts})
 

--- a/cmake/projects/Boost/serialization/hunter.cmake
+++ b/cmake/projects/Boost/serialization/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     serialization
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/signals/hunter.cmake
+++ b/cmake/projects/Boost/signals/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     signals
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/stacktrace/hunter.cmake
+++ b/cmake/projects/Boost/stacktrace/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     stacktrace
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/system/hunter.cmake
+++ b/cmake/projects/Boost/system/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     system
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/test/hunter.cmake
+++ b/cmake/projects/Boost/test/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     test
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/thread/hunter.cmake
+++ b/cmake/projects/Boost/thread/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     thread
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/timer/hunter.cmake
+++ b/cmake/projects/Boost/timer/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     timer
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/cmake/projects/Boost/wave/hunter.cmake
+++ b/cmake/projects/Boost/wave/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     wave
-    PACKAGE_INTERNAL_DEPS_ID "36"
+    PACKAGE_INTERNAL_DEPS_ID "37"
 )

--- a/docs/packages/pkg/Boost.rst
+++ b/docs/packages/pkg/Boost.rst
@@ -65,7 +65,7 @@ config file (``boost/config/user.hpp``):
    options <http://www.boost.org/doc/libs/1_57_0/libs/iostreams/doc/index.html?path=7>`__
 
 - Options ``CONFIG_MACRO_<ID>=<VALUE>`` will append ``#define <ID> <VALUE>``
-  to the default boost user config file. And options
+  to the default boost user config header file. And options
   ``CONFIG_MACRO=<ID_1>;<ID_2>;...;<ID_n>`` will append ``#define <ID_1>``,
   ``#define <ID_2>``, ..., ``#define <ID_n>``.
   Example:
@@ -87,6 +87,68 @@ config file (``boost/config/user.hpp``):
     #define BOOST_REGEX_MATCH_EXTRA
     #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
     #define BOOST_MPL_LIMIT_LIST_SIZE 3
+
+Python
+------
+
+To require Boost Python to be built against a specific version of Python installed
+on the system, option ``REQUESTED_PYTHON_VERSION=<VALUE>`` may be used. In this case,
+if the required components of Python are located, ``user_config.jam``
+will be appended with the following line:
+
+.. code-block:: none
+
+  using python  : <requested_version_number> : <path to Python executable> :
+  <path to Python include directory> : <path to directory containing the Python library> ;
+
+Example for Python 2:
+
+.. code-block:: cmake
+
+    # config.cmake
+    hunter_config(
+      Boost
+      VERSION ${HUNTER_Boost_VERSION}
+      CMAKE_ARGS
+      REQUESTED_PYTHON_VERSION=2.7.15
+    )
+
+.. code-block:: cmake
+
+    # CMakeLists.txt
+    hunter_add_package(Boost COMPONENTS python)
+    if(Boost_VERSION VERSION_LESS 106700)
+      find_package(Boost CONFIG REQUIRED python)
+    else()
+      find_package(Boost CONFIG REQUIRED python27)
+    endif()
+
+.. note::
+
+  Python<x> component arguments to ``find_package(Boost ...)`` after Boost version 1.67 require
+  a specific version suffix, e.g. python37.
+
+Example for Python 3:
+
+.. code-block:: cmake
+
+    # config.cmake
+    hunter_config(
+      Boost
+      VERSION ${HUNTER_Boost_VERSION}
+      CMAKE_ARGS
+      REQUESTED_PYTHON_VERSION=3.6.7
+    )
+
+.. code-block:: cmake
+
+    # CMakeLists.txt
+    hunter_add_package(Boost COMPONENTS python)
+    if(Boost_VERSION VERSION_LESS 106700)
+      find_package(Boost CONFIG REQUIRED python3)
+    else()
+      find_package(Boost CONFIG REQUIRED python36)
+    endif()
 
 Math
 ----

--- a/examples/Boost-python/CMakeLists.txt
+++ b/examples/Boost-python/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.2)
 option(HUNTER_BUILD_SHARED_LIBS "..." ON)
 
 # Configure:
-set(REQUESTED_PYTHON_VERSION 3.6.7)
+set(REQUESTED_PYTHON_VERSION 3.5)
 set(TESTING_CONFIG_OPT FILEPATH "${CMAKE_CURRENT_LIST_DIR}/config.cmake")
 
 # Emulate HunterGate:
@@ -17,14 +17,14 @@ project(download-boost)
 
 # Requires python version 3.6.7. Change this in config.cmake if necessary.
 hunter_add_package(Boost COMPONENTS python)
-find_package(Boost CONFIG REQUIRED python36)
+find_package(Boost CONFIG REQUIRED python35)
 find_package(PythonLibs ${REQUESTED_PYTHON_VERSION} EXACT REQUIRED)
 
 add_library(foo foo.cpp)
 target_link_libraries(
     foo
     PUBLIC
-    Boost::python36
+    Boost::python35
 )
 target_include_directories(
   foo

--- a/examples/Boost-python/CMakeLists.txt
+++ b/examples/Boost-python/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright (c) 2013, Ruslan Baratov
+# Modified work: Copyright (c) 2018, Gregory Kramida
+# All rights reserved.
+
+cmake_minimum_required(VERSION 3.2)
+option(HUNTER_BUILD_SHARED_LIBS "..." ON)
+
+# Configure:
+set(REQUESTED_PYTHON_VERSION 3.6.7)
+set(TESTING_CONFIG_OPT FILEPATH "${CMAKE_CURRENT_LIST_DIR}/config.cmake")
+
+# Emulate HunterGate:
+# * https://github.com/hunter-packages/gate
+include("../common.cmake")
+
+project(download-boost)
+
+# Requires python version 3.6.7. Change this in config.cmake if necessary.
+hunter_add_package(Boost COMPONENTS python)
+find_package(Boost CONFIG REQUIRED python36)
+find_package(PythonLibs ${REQUESTED_PYTHON_VERSION} EXACT REQUIRED)
+
+add_library(foo foo.cpp)
+target_link_libraries(
+    foo
+    PUBLIC
+    Boost::python36
+)
+target_include_directories(
+  foo
+  PUBLIC
+  ${PYTHON_INCLUDE_DIR}
+)

--- a/examples/Boost-python/config.cmake
+++ b/examples/Boost-python/config.cmake
@@ -1,0 +1,3 @@
+# Note: REQUESTED_PYTHON_VERSION is optional. Refer to Boost package documentation on how
+# and when to use it: https://docs.hunter.sh/en/latest/packages/pkg/Boost.html#cmake-options
+hunter_config(Boost VERSION ${HUNTER_Boost_VERSION} CMAKE_ARGS REQUESTED_PYTHON_VERSION=${REQUESTED_PYTHON_VERSION})

--- a/examples/Boost-python/foo.cpp
+++ b/examples/Boost-python/foo.cpp
@@ -1,0 +1,12 @@
+#include <boost/python.hpp>
+
+char const* greet()
+{
+   return "hello, world";
+}
+
+BOOST_PYTHON_MODULE(hello_ext)
+{
+    using namespace boost::python;
+    def("greet", greet);
+}


### PR DESCRIPTION
1. REQUESTED_PYTHON_VERSION added, tested for boost 1.66.0 and 1.68.0-p1 on Ubuntu
2. Example added showing how to use Hunter with Boost Python and the REQUESTED_PYTHON_VERSION option 
3. Boost Package documentation updated with info about REQUESTED_PYTHON_VERSION option

Should resolve https://github.com/ruslo/hunter/issues/1660