### PR TITLE
Update 'Protobuf' to v3.6.1.3-p0

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -106,7 +106,7 @@ hunter_default_version(PROJ4 VERSION 5.0.0)
 hunter_default_version(PhysUnits VERSION 1.1.0-p0)
 hunter_default_version(PocoCpp VERSION 1.7.9-p1)
 hunter_default_version(PostgreSQL VERSION 10.0.0)
-hunter_default_version(Protobuf VERSION 3.5.2-p0)
+hunter_default_version(Protobuf VERSION 3.6.1.3-p0)
 
 string(COMPARE EQUAL "${CMAKE_SYSTEM_NAME}" "Linux" _is_linux)
 if(_is_linux OR MINGW)

--- a/cmake/projects/Protobuf/hunter.cmake
+++ b/cmake/projects/Protobuf/hunter.cmake
@@ -10,6 +10,17 @@ hunter_add_version(
     PACKAGE_NAME
     Protobuf
     VERSION
+    "2.4.1-p0"
+    URL
+    "https://github.com/hunter-packages/protobuf/archive/v2.4.1-p0.tar.gz"
+    SHA1
+    c57c846131f804622057d83bf44144c179613e44
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Protobuf
+    VERSION
     "3.0.0-p1"
     URL
     "https://github.com/hunter-packages/protobuf/archive/v3.0.0-hunter-3.tar.gz"
@@ -73,16 +84,26 @@ hunter_add_version(
 )
 
 hunter_add_version(
-    PACKAGE_NAME Protobuf
-    VERSION "3.5.2-p0"
-    URL "https://github.com/hunter-packages/protobuf/archive/v3.5.2-p0.tar.gz"
-    SHA1 "0c1eacb460266dea7cd18c2009642fa192c15b70")
+    PACKAGE_NAME
+    Protobuf
+    VERSION
+    "3.5.2-p0"
+    URL
+    "https://github.com/hunter-packages/protobuf/archive/v3.5.2-p0.tar.gz"
+    SHA1
+    0c1eacb460266dea7cd18c2009642fa192c15b70
+)
 
 hunter_add_version(
-    PACKAGE_NAME Protobuf
-    VERSION "2.4.1-p0"
-    URL "https://github.com/hunter-packages/protobuf/archive/v2.4.1-p0.tar.gz"
-    SHA1 "c57c846131f804622057d83bf44144c179613e44")
+    PACKAGE_NAME
+    Protobuf
+    VERSION
+    "3.6.1.3-p0"
+    URL
+    "https://github.com/hunter-packages/protobuf/archive/v3.6.1.3-p0.tar.gz"
+    SHA1
+    5f32dcd70bed20e42cecc53058b8502298c6680a
+)
 
 string(
     COMPARE EQUAL "${CMAKE_SYSTEM_NAME}" "WindowsStore" _hunter_windows_store


### PR DESCRIPTION
* I've followed [this guide](https://docs.hunter.sh/en/latest/creating-new/update.html)
  step by step carefully. **Yes**

* I've tested this package remotely and have excluded all broken builds.
  Here is the links to the Travis/AppVeyor with status "All passed":

  * https://ci.appveyor.com/project/rbsheth/hunter/builds/21133967
  * https://travis-ci.com/rbsheth/hunter/builds/95334504

I also cleaned up the `Protobuf/hunter.cmake` file to make it more consistent.