### PR TITLE
rename PYTHON_VERSION arg, fix Boost jamfile python line

### DIFF
--- a/cmake/projects/Boost/atomic/hunter.cmake
+++ b/cmake/projects/Boost/atomic/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     atomic
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/chrono/hunter.cmake
+++ b/cmake/projects/Boost/chrono/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     chrono
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/context/hunter.cmake
+++ b/cmake/projects/Boost/context/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     context
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/contract/hunter.cmake
+++ b/cmake/projects/Boost/contract/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     contract
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/coroutine/hunter.cmake
+++ b/cmake/projects/Boost/coroutine/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     coroutine
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/date_time/hunter.cmake
+++ b/cmake/projects/Boost/date_time/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     date_time
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/exception/hunter.cmake
+++ b/cmake/projects/Boost/exception/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     exception
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/fiber/hunter.cmake
+++ b/cmake/projects/Boost/fiber/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     fiber
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/filesystem/hunter.cmake
+++ b/cmake/projects/Boost/filesystem/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     filesystem
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/graph/hunter.cmake
+++ b/cmake/projects/Boost/graph/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/graph_parallel/hunter.cmake
+++ b/cmake/projects/Boost/graph_parallel/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph_parallel
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -367,4 +367,4 @@ endif()
 
 hunter_pick_scheme(DEFAULT url_sha1_boost)
 hunter_cacheable(Boost)
-hunter_download(PACKAGE_NAME Boost PACKAGE_INTERNAL_DEPS_ID "37")
+hunter_download(PACKAGE_NAME Boost PACKAGE_INTERNAL_DEPS_ID "38")

--- a/cmake/projects/Boost/hunter.cmake.in
+++ b/cmake/projects/Boost/hunter.cmake.in
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     boost_component
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/iostreams/hunter.cmake
+++ b/cmake/projects/Boost/iostreams/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     iostreams
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/locale/hunter.cmake
+++ b/cmake/projects/Boost/locale/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     locale
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/log/hunter.cmake
+++ b/cmake/projects/Boost/log/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     log
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/math/hunter.cmake
+++ b/cmake/projects/Boost/math/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     math
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/mpi/hunter.cmake
+++ b/cmake/projects/Boost/mpi/hunter.cmake
@@ -26,5 +26,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     mpi
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/program_options/hunter.cmake
+++ b/cmake/projects/Boost/program_options/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     program_options
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/python/hunter.cmake
+++ b/cmake/projects/Boost/python/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     python
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/random/hunter.cmake
+++ b/cmake/projects/Boost/random/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     random
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/regex/hunter.cmake
+++ b/cmake/projects/Boost/regex/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     regex
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
@@ -292,15 +292,15 @@ file(
 # handle requested python version if such is specified
 hunter_parse_cmake_args_for_keyword(
   CMAKE_ARGS "@HUNTER_Boost_CMAKE_ARGS@"
-  KEYWORD REQUESTED_PYTHON_VERSION
-  OUTPUT requested_python
+  KEYWORD PYTHON_VERSION
+  OUTPUT python_version
 )
 
 # set up paths for python in boost.user.jam
-if(NOT requested_python STREQUAL "")
-  find_package(PythonInterp ${requested_python} EXACT QUIET)
+if(NOT python_version STREQUAL "")
+  find_package(PythonInterp ${python_version} EXACT QUIET)
   if(NOT PYTHONINTERP_FOUND)
-    hunter_user_error("Python Interpreter for Python version ${requested_python} not found.")
+    hunter_user_error("Python Interpreter for Python version ${python_version} not found.")
   endif()
   set(python_executable ${PYTHON_EXECUTABLE})
   execute_process(
@@ -310,7 +310,7 @@ if(NOT requested_python STREQUAL "")
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
   if(NOT python_process EQUAL 0)
-    hunter_user_error("Python include directory for Python version ${requested_python} not found.")
+    hunter_user_error("Python include directory for Python version ${python_version} not found.")
   endif()
   if(NOT EXISTS "${python_include_directory}")
     hunter_internal_error("Directory not found: ${python_include_directory}")
@@ -322,14 +322,14 @@ if(NOT requested_python STREQUAL "")
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
   if(NOT python_process EQUAL 0)
-    hunter_user_error("Python runtime library directory for Python version ${requested_python} not found.")
+    hunter_user_error("Python runtime library directory for Python version ${python_version} not found.")
   endif()
   if(NOT EXISTS "${python_library_directory}")
     hunter_internal_error("Directory not found: ${python_library_directory}")
   endif()
   file(
     APPEND ${boost_user_jam}
-    "using python  : ${requested_python} : \"${python_executable}\" : \"${python_include_directory}\" : \"${python_library_directory}\" ;\n"
+    "using python  : ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR} : \"${python_executable}\" : \"${python_include_directory}\" : \"${python_library_directory}\" ;\n"
   )
 endif()
 

--- a/cmake/projects/Boost/serialization/hunter.cmake
+++ b/cmake/projects/Boost/serialization/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     serialization
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/signals/hunter.cmake
+++ b/cmake/projects/Boost/signals/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     signals
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/stacktrace/hunter.cmake
+++ b/cmake/projects/Boost/stacktrace/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     stacktrace
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/system/hunter.cmake
+++ b/cmake/projects/Boost/system/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     system
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/test/hunter.cmake
+++ b/cmake/projects/Boost/test/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     test
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/thread/hunter.cmake
+++ b/cmake/projects/Boost/thread/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     thread
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/timer/hunter.cmake
+++ b/cmake/projects/Boost/timer/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     timer
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/cmake/projects/Boost/wave/hunter.cmake
+++ b/cmake/projects/Boost/wave/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     wave
-    PACKAGE_INTERNAL_DEPS_ID "37"
+    PACKAGE_INTERNAL_DEPS_ID "38"
 )

--- a/docs/packages/pkg/Boost.rst
+++ b/docs/packages/pkg/Boost.rst
@@ -92,7 +92,7 @@ Python
 ------
 
 To require Boost Python to be built against a specific version of Python installed
-on the system, option ``REQUESTED_PYTHON_VERSION=<VALUE>`` may be used. In this case,
+on the system, option ``PYTHON_VERSION=<VALUE>`` may be used. In this case,
 if the required components of Python are located, ``user_config.jam``
 will be appended with the following line:
 
@@ -110,7 +110,7 @@ Example for Python 2:
       Boost
       VERSION ${HUNTER_Boost_VERSION}
       CMAKE_ARGS
-      REQUESTED_PYTHON_VERSION=2.7.15
+      PYTHON_VERSION=2.7.15
     )
 
 .. code-block:: cmake
@@ -137,7 +137,7 @@ Example for Python 3:
       Boost
       VERSION ${HUNTER_Boost_VERSION}
       CMAKE_ARGS
-      REQUESTED_PYTHON_VERSION=3.6.7
+      PYTHON_VERSION=3.6.7
     )
 
 .. code-block:: cmake

--- a/examples/Boost-python/CMakeLists.txt
+++ b/examples/Boost-python/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.2)
 option(HUNTER_BUILD_SHARED_LIBS "..." ON)
 
 # Configure:
-set(REQUESTED_PYTHON_VERSION 3.5)
+set(PYTHON_VERSION 3.5)
 set(TESTING_CONFIG_OPT FILEPATH "${CMAKE_CURRENT_LIST_DIR}/config.cmake")
 
 # Emulate HunterGate:
@@ -15,10 +15,10 @@ include("../common.cmake")
 
 project(download-boost)
 
-# Requires python version 3.6.7. Change this in config.cmake if necessary.
+# Requires python version 3.5. Change this in config.cmake if necessary.
 hunter_add_package(Boost COMPONENTS python)
 find_package(Boost CONFIG REQUIRED python35)
-find_package(PythonLibs ${REQUESTED_PYTHON_VERSION} EXACT REQUIRED)
+find_package(PythonLibs ${PYTHON_VERSION} EXACT REQUIRED)
 
 add_library(foo foo.cpp)
 target_link_libraries(

--- a/examples/Boost-python/config.cmake
+++ b/examples/Boost-python/config.cmake
@@ -1,3 +1,3 @@
-# Note: REQUESTED_PYTHON_VERSION is optional. Refer to Boost package documentation on how
+# Note: PYTHON_VERSION is optional. Refer to Boost package documentation on how
 # and when to use it: https://docs.hunter.sh/en/latest/packages/pkg/Boost.html#cmake-options
-hunter_config(Boost VERSION ${HUNTER_Boost_VERSION} CMAKE_ARGS REQUESTED_PYTHON_VERSION=${REQUESTED_PYTHON_VERSION})
+hunter_config(Boost VERSION ${HUNTER_Boost_VERSION} CMAKE_ARGS PYTHON_VERSION=${PYTHON_VERSION})


### PR DESCRIPTION
1) Rename REQUESTED_PYTHON_VERSION --> PYTHON_VERSION for CMAKE_ARGS of the Boost package in `hunter_config(Boost`
2) Use <major_version>.<minor_version> for "use python" line in Boost user_config.jam file, instead of <major.minor.patch>, to avert Boost warning

<!--- Use this part of template if you're updating existing package. Remove the rest. -->
<!--- BEGIN -->

* I've followed [this guide](https://docs.hunter.sh/en/latest/creating-new/update.html)
  step by step carefully. **[Yes]**

* I've tested this package remotely and have excluded all broken builds.
  Here is the links to the Travis/AppVeyor with status "All passed":

  * https://ci.appveyor.com/project/Algomorph/hunter/builds/21181700
  * https://travis-ci.com/Algomorph/hunter/builds/95567906
<!--- END -->

