### PR TITLE
Force hard link when unpacking dir

### DIFF
--- a/cmake/modules/hunter_unpack_directory.cmake
+++ b/cmake/modules/hunter_unpack_directory.cmake
@@ -101,7 +101,7 @@ function(hunter_unpack_directory cache_sha1)
       file(
           APPEND
           "${shell_link_script}"
-          "ln \\\n  \"\${HUNTER_CELLAR_RAW_DIRECTORY}/${x}\" \\\n  \"\$1/${x}\"\n\n"
+          "ln -f \\\n  \"\${HUNTER_CELLAR_RAW_DIRECTORY}/${x}\" \\\n  \"\$1/${x}\"\n\n"
        )
     endforeach()
     # }


### PR DESCRIPTION
<!--- Use this part of template for other type of changes. Remove the rest. -->
<!--- BEGIN -->

When unpacking the directory, there is a step where hunter creates a hard link from files in your Cellar directory, to files in your Install directory for the toolchain+config combination of that build run. The hard link will fail if the files already exist in the install directory.

I encountered this error when building protobuf 3.6.1, as hunter attempted to build protobuf from source (cache miss), but the files in the Install folder already existed.

```
[hunter ** INTERNAL **] Link script failed: 1, , Link files using Python: /usr/bin/python3
CMake Warning at /home/ubuntu/monorepo/hunter/hunter/scripts/link-all.cmake:70 (message):
  Python script failed:
  /usr/bin/python3
[hunter ** INTERNAL **] /home/ubuntu/monorepo/hunter/hunter/scripts/link-all.py
[hunter ** INTERNAL **] --list
[hunter ** INTERNAL **] /home/ubuntu/monorepo/hunter/hunter/_Base/Cellar/8536507487ca468150322f46f4147bd881d8f721/8536507/files.list
[hunter ** INTERNAL **] --cellar
[hunter ** INTERNAL **] /home/ubuntu/monorepo/hunter/hunter/_Base/Cellar/8536507487ca468150322f46f4147bd881d8f721/8536507/raw
[hunter ** INTERNAL **] --dest
[hunter ** INTERNAL **] /home/ubuntu/monorepo/hunter/hunter/_Base/xxxxxxx/b6a0ae2/9bcf801/Install,
  1, Exception caught: [Errno 5] Input/output error:
  '/home/ubuntu/monorepo/hunter/hunter/_Base/Cellar/8536507487ca468150322f46f4147bd881d8f721/8536507/raw/bin/protoc'
  ->
  '/home/ubuntu/monorepo/hunter/hunter/_Base/xxxxxxx/b6a0ae2/9bcf801/Install/bin/protoc'


  , Some job failed

  (may help: https://stackoverflow.com/a/2009505/2288008)


Link files using shell: /bin/bash
CMake Error at /home/ubuntu/monorepo/hunter/hunter/scripts/link-all.cmake:92 (message):
  Shell script failed:
  /bin/bash
[hunter ** INTERNAL **] /home/ubuntu/monorepo/hunter/hunter/_Base/Cellar/8536507487ca468150322f46f4147bd881d8f721/8536507/link-all.sh
[hunter ** INTERNAL **] /home/ubuntu/monorepo/hunter/hunter/_Base/xxxxxxx/b6a0ae2/9bcf801/Install,
  1, , ln: failed to create hard link
  '/home/ubuntu/monorepo/hunter/hunter/_Base/xxxxxxx/b6a0ae2/9bcf801/Install/bin/protoc':
  File exists
```

I'm not sure why it was in this state, but a simple fix is to force the hard link.

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

---
<!--- END -->

PTAL @ruslo 