### PR TITLE
WIP Update Catch to 2.5.0

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -48,7 +48,7 @@ hunter_default_version(CLAPACK VERSION 3.2.1)
 hunter_default_version(CLI11 VERSION 1.6.1)
 hunter_default_version(CURL VERSION 7.60.0-p0)
 hunter_default_version(CapnProto VERSION 0.7.0)
-hunter_default_version(Catch VERSION 2.2.2)
+hunter_default_version(Catch VERSION 2.5.0)
 hunter_default_version(Clang VERSION 6.0.1-p0)
 hunter_default_version(ClangToolsExtra VERSION 6.0.1) # Clang
 hunter_default_version(Comet VERSION 4.0.2)

--- a/cmake/projects/Catch/hunter.cmake
+++ b/cmake/projects/Catch/hunter.cmake
@@ -13,6 +13,17 @@ hunter_add_version(
     PACKAGE_NAME
     Catch
     VERSION
+    "2.5.0"
+    URL
+    "https://github.com/catchorg/Catch2/archive/v2.5.0.tar.gz"
+    SHA1
+    55fa742c9d2b6890da7060ca8c58693e7c8929fb
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Catch
+    VERSION
     "2.2.2"
     URL
     "https://github.com/catchorg/Catch2/archive/v2.2.2.tar.gz"
@@ -67,7 +78,7 @@ hunter_add_version(
 hunter_cmake_args(
   Catch
   CMAKE_ARGS
-    NO_SELFTEST=TRUE
+  NO_SELFTEST=TRUE CATCH_BUILD_TESTING=OFF
 )
 
 hunter_pick_scheme(DEFAULT url_sha1_cmake)

--- a/examples/Catch/CMakeLists.txt
+++ b/examples/Catch/CMakeLists.txt
@@ -20,5 +20,5 @@ set(SOURCES main.cpp
 set(HEADERS foo.hpp)
 
 add_executable(foo_test ${SOURCES} ${HEADERS})
-target_link_libraries(foo_test PUBLIC Catch2::Catch)
+target_link_libraries(foo_test PUBLIC Catch2::Catch2)
 # DOCUMENTATION_END }

--- a/examples/Catch/foo_test.cpp
+++ b/examples/Catch/foo_test.cpp
@@ -1,4 +1,4 @@
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include "foo.hpp"
 
 namespace ns_foo {

--- a/examples/Catch/main.cpp
+++ b/examples/Catch/main.cpp
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>


### PR DESCRIPTION
The switch for not building tests was renamed in v2.3. Furthermore, the
header name and target name for catch was updated.

Am I supposed to keep both the old and the new option in the call of the `hunter_cmake_args` call to support the old versions as well? Or should I go ahead and purge the old versions?

Fixes ruslo/hunter#1700

* I've followed [this guide](https://docs.hunter.sh/en/latest/creating-new/update.html)
  step by step carefully. YES

* I've tested this package remotely and have excluded all broken builds.
  Here is the links to the Travis/AppVeyor with status "All passed":

  * https://ci.appveyor.com/project/kaihowl/hunter/builds/21570606
  * https://travis-ci.com/kaihowl/hunter/builds/97127152
