### PR TITLE
Fix PYTHON_VERSION config arg handling on MSVC (+ Boost-python example change)

### DIFF
--- a/cmake/projects/Boost/atomic/hunter.cmake
+++ b/cmake/projects/Boost/atomic/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     atomic
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/chrono/hunter.cmake
+++ b/cmake/projects/Boost/chrono/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     chrono
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/context/hunter.cmake
+++ b/cmake/projects/Boost/context/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     context
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/contract/hunter.cmake
+++ b/cmake/projects/Boost/contract/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     contract
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/coroutine/hunter.cmake
+++ b/cmake/projects/Boost/coroutine/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     coroutine
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/date_time/hunter.cmake
+++ b/cmake/projects/Boost/date_time/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     date_time
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/exception/hunter.cmake
+++ b/cmake/projects/Boost/exception/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     exception
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/fiber/hunter.cmake
+++ b/cmake/projects/Boost/fiber/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     fiber
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/filesystem/hunter.cmake
+++ b/cmake/projects/Boost/filesystem/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     filesystem
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/graph/hunter.cmake
+++ b/cmake/projects/Boost/graph/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/graph_parallel/hunter.cmake
+++ b/cmake/projects/Boost/graph_parallel/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph_parallel
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -378,4 +378,4 @@ endif()
 
 hunter_pick_scheme(DEFAULT url_sha1_boost)
 hunter_cacheable(Boost)
-hunter_download(PACKAGE_NAME Boost PACKAGE_INTERNAL_DEPS_ID "38")
+hunter_download(PACKAGE_NAME Boost PACKAGE_INTERNAL_DEPS_ID "39")

--- a/cmake/projects/Boost/hunter.cmake.in
+++ b/cmake/projects/Boost/hunter.cmake.in
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     boost_component
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/iostreams/hunter.cmake
+++ b/cmake/projects/Boost/iostreams/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     iostreams
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/locale/hunter.cmake
+++ b/cmake/projects/Boost/locale/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     locale
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/log/hunter.cmake
+++ b/cmake/projects/Boost/log/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     log
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/math/hunter.cmake
+++ b/cmake/projects/Boost/math/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     math
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/mpi/hunter.cmake
+++ b/cmake/projects/Boost/mpi/hunter.cmake
@@ -26,5 +26,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     mpi
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/program_options/hunter.cmake
+++ b/cmake/projects/Boost/program_options/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     program_options
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/python/hunter.cmake
+++ b/cmake/projects/Boost/python/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     python
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/random/hunter.cmake
+++ b/cmake/projects/Boost/random/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     random
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/regex/hunter.cmake
+++ b/cmake/projects/Boost/regex/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     regex
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
@@ -303,22 +303,18 @@ if(NOT python_version STREQUAL "")
     hunter_user_error("Python Interpreter for Python version ${python_version} not found.")
   endif()
   set(python_executable ${PYTHON_EXECUTABLE})
-  execute_process(
-    COMMAND "${python_executable}" -c "import os.path, sysconfig; info = sysconfig.get_paths(); print(info['include'])"
-    RESULT_VARIABLE python_process
-    OUTPUT_VARIABLE python_include_directory
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-  if(NOT python_process EQUAL 0)
-    hunter_user_error("Python include directory for Python version ${python_version} not found.")
-  endif()
-  if(NOT EXISTS "${python_include_directory}")
-    hunter_internal_error("Directory not found: ${python_include_directory}")
-  endif()
   find_package(PythonLibs ${python_version} EXACT QUIET)
   if(NOT PYTHONLIBS_FOUND)
     hunter_user_error("Python runtime library directory for Python version ${python_version} not found.")
   endif()
+  # get the main Python include directory containing pyconfig.h
+  list(LENGTH PYTHON_INCLUDE_DIRS python_include_dir_list_length)
+  if(python_include_dir_list_length EQUAL 1)
+    set(python_include_directory "${PYTHON_INCLUDE_DIRS}")
+  else()
+    list(GET PYTHON_INCLUDE_DIRS 0 python_include_directory)
+  endif()
+  # get directory of optimized library
   list(LENGTH PYTHON_LIBRARIES python_libraries_list_length)
   if(python_libraries_list_length EQUAL 1)
     set(python_optimized_library_path "${PYTHON_LIBRARIES}")
@@ -328,7 +324,7 @@ if(NOT python_version STREQUAL "")
   get_filename_component(python_library_directory "${python_optimized_library_path}" DIRECTORY)
   if("@MSVC@")
     string(REPLACE "/" "\\\\" python_executable "${python_executable}")
-    string(REPLACE "\\" "\\\\" python_include_directory "${python_include_directory}")
+    string(REPLACE "/" "\\\\" python_include_directory "${python_include_directory}")
     string(REPLACE "/" "\\\\" python_library_directory "${python_library_directory}")
   endif()
   file(

--- a/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
@@ -315,17 +315,21 @@ if(NOT python_version STREQUAL "")
   if(NOT EXISTS "${python_include_directory}")
     hunter_internal_error("Directory not found: ${python_include_directory}")
   endif()
-  execute_process(
-    COMMAND "${python_executable}" -c "import os.path, sysconfig; info = sysconfig.get_paths(); print(os.path.dirname(info['stdlib']))"
-    RESULT_VARIABLE python_process
-    OUTPUT_VARIABLE python_library_directory
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-  if(NOT python_process EQUAL 0)
+  find_package(PythonLibs ${python_version} EXACT QUIET)
+  if(NOT PYTHONLIBS_FOUND)
     hunter_user_error("Python runtime library directory for Python version ${python_version} not found.")
   endif()
-  if(NOT EXISTS "${python_library_directory}")
-    hunter_internal_error("Directory not found: ${python_library_directory}")
+  list(LENGTH PYTHON_LIBRARIES python_libraries_list_length)
+  if(python_libraries_list_length EQUAL 1)
+    set(python_optimized_library_path "${PYTHON_LIBRARIES}")
+  else()
+    list(GET PYTHON_LIBRARIES 1 python_optimized_library_path)
+  endif()
+  get_filename_component(python_library_directory "${python_optimized_library_path}" DIRECTORY)
+  if("@MSVC@")
+    string(REPLACE "/" "\\\\" python_executable "${python_executable}")
+    string(REPLACE "\\" "\\\\" python_include_directory "${python_include_directory}")
+    string(REPLACE "/" "\\\\" python_library_directory "${python_library_directory}")
   endif()
   file(
     APPEND ${boost_user_jam}

--- a/cmake/projects/Boost/serialization/hunter.cmake
+++ b/cmake/projects/Boost/serialization/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     serialization
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/signals/hunter.cmake
+++ b/cmake/projects/Boost/signals/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     signals
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/stacktrace/hunter.cmake
+++ b/cmake/projects/Boost/stacktrace/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     stacktrace
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/system/hunter.cmake
+++ b/cmake/projects/Boost/system/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     system
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/test/hunter.cmake
+++ b/cmake/projects/Boost/test/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     test
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/thread/hunter.cmake
+++ b/cmake/projects/Boost/thread/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     thread
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/timer/hunter.cmake
+++ b/cmake/projects/Boost/timer/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     timer
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/cmake/projects/Boost/wave/hunter.cmake
+++ b/cmake/projects/Boost/wave/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     wave
-    PACKAGE_INTERNAL_DEPS_ID "38"
+    PACKAGE_INTERNAL_DEPS_ID "39"
 )

--- a/examples/Boost-python/CMakeLists.txt
+++ b/examples/Boost-python/CMakeLists.txt
@@ -20,7 +20,7 @@ hunter_add_package(Boost COMPONENTS python)
 find_package(Boost CONFIG REQUIRED python35)
 find_package(PythonLibs ${PYTHON_VERSION} EXACT REQUIRED)
 
-add_library(foo foo.cpp)
+PYTHON_ADD_MODULE(foo foo.cpp)
 target_link_libraries(
     foo
     PUBLIC


### PR DESCRIPTION
<!--- Use this part of template if you're updating existing package. Remove the rest. -->
<!--- BEGIN -->

* I've followed [this guide](https://docs.hunter.sh/en/latest/creating-new/update.html)
  step by step carefully. **[Yes]**

* I've tested this package remotely and have excluded all broken builds.
  Here is the links to the Travis/AppVeyor with status "All passed":

  * https://travis-ci.com/Algomorph/hunter/builds/97328682
  * https://ci.appveyor.com/project/Algomorph/hunter

(Master branch is at the same commit as pr.boost)
Hopefully, now I've done the testing correctly... Let me know if not...

Changes summary:

1) Use standard FindPythonLibs instead of getting library location from interpreter,
which is more semantically correct and doesn't break on Windows
2) Replace single back- and forward-slashes in python paths of user_config.jam file with
escaped backslashes for MSVC only (otherwise, build breaks on MSVC)
3) Push PACKAGE_INTERNAL_DEPS_ID up to 39.
4) Use PYTHON_ADD_MODULE command in Boost-python instead of add_library in the Boost-python example: PYTHON_ADD_MODULE is the more correct way (builds a shared library with proper name/extension modifications on all platforms).

<!--- Remove next line if this update doesn't break old toolchains -->

---
<!--- END -->
