### PR TITLE
Update catch to 2.6.0

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -48,7 +48,7 @@ hunter_default_version(CLAPACK VERSION 3.2.1)
 hunter_default_version(CLI11 VERSION 1.7.1)
 hunter_default_version(CURL VERSION 7.60.0-p0)
 hunter_default_version(CapnProto VERSION 0.7.0)
-hunter_default_version(Catch VERSION 2.5.0)
+hunter_default_version(Catch VERSION 2.6.0)
 hunter_default_version(Clang VERSION 6.0.1-p0)
 hunter_default_version(ClangToolsExtra VERSION 6.0.1) # Clang
 hunter_default_version(Comet VERSION 4.0.2)

--- a/cmake/projects/Catch/hunter.cmake
+++ b/cmake/projects/Catch/hunter.cmake
@@ -13,6 +13,17 @@ hunter_add_version(
     PACKAGE_NAME
     Catch
     VERSION
+    "2.6.0"
+    URL
+    "https://github.com/catchorg/Catch2/archive/v2.6.0.tar.gz"
+    SHA1
+    e32263de5489cfaf57d1a059f1f901312b81f7d1
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Catch
+    VERSION
     "2.5.0"
     URL
     "https://github.com/catchorg/Catch2/archive/v2.5.0.tar.gz"


### PR DESCRIPTION
* I've followed [this guide](https://docs.hunter.sh/en/latest/creating-new/update.html)
  step by step carefully. YES

* I've tested this package remotely and have excluded all broken builds.
  Here is the links to the Travis/AppVeyor with status "All passed":

  * https://ci.appveyor.com/project/kaihowl/hunter/builds/22066576
  * https://travis-ci.com/kaihowl/hunter/builds/99485097