### PR TITLE
 Fixed GLFW build on systems having lib64 set as the CMAKE_INSTALL_LIBDIR 

### DIFF
--- a/cmake/projects/glfw/hunter.cmake
+++ b/cmake/projects/glfw/hunter.cmake
@@ -108,8 +108,7 @@ hunter_download(
     # Patching of glfw3Targets.cmake required as it has full paths due to the lack
     # of imported targets for x11 packages. This should be removed when
     # https://github.com/ruslo/hunter/issues/486 is implemented
-    "${CMAKE_INSTALL_LIBDIR}/cmake/glfw3/glfw3Targets.cmake"
-    "${CMAKE_INSTALL_LIBDIR}/pkgconfig/glfw3.pc"
-
+      "${CMAKE_INSTALL_LIBDIR}/cmake/glfw3/glfw3Targets.cmake"
+      "${CMAKE_INSTALL_LIBDIR}/pkgconfig/glfw3.pc"
 
 )

--- a/cmake/projects/glfw/hunter.cmake
+++ b/cmake/projects/glfw/hunter.cmake
@@ -11,6 +11,7 @@ include(hunter_cacheable)
 include(hunter_cmake_args)
 include(hunter_download)
 include(hunter_pick_scheme)
+include(GNUInstallDirs)
 
 hunter_add_version(
     PACKAGE_NAME
@@ -107,7 +108,8 @@ hunter_download(
     # Patching of glfw3Targets.cmake required as it has full paths due to the lack
     # of imported targets for x11 packages. This should be removed when
     # https://github.com/ruslo/hunter/issues/486 is implemented
-      "lib/cmake/glfw3/glfw3Targets.cmake"
-      "lib/pkgconfig/glfw3.pc"
+    "${CMAKE_INSTALL_LIBDIR}/cmake/glfw3/glfw3Targets.cmake"
+    "${CMAKE_INSTALL_LIBDIR}/pkgconfig/glfw3.pc"
+
 
 )


### PR DESCRIPTION

<!--- BEGIN -->

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

---
<!--- END -->
