### PR TITLE
Fix "unstaged changes" errors with Hunter cache on Windows

### DIFF
--- a/scripts/upload-cache-to-github.py
+++ b/scripts/upload-cache-to-github.py
@@ -406,6 +406,9 @@ class Cache:
         "{}@users.noreply.github.com".format(github.username)
     )
     config.set_value("user", "name", github.username)
+    if sys.platform == "win32":
+        config.set_value("core.autocrlf", "input")
+
     config.release()
 
     if self.repo.is_dirty(untracked_files=True):

--- a/scripts/upload-cache-to-github.py
+++ b/scripts/upload-cache-to-github.py
@@ -407,7 +407,7 @@ class Cache:
     )
     config.set_value("user", "name", github.username)
     if sys.platform == "win32":
-        config.set_value("core.autocrlf", "input")
+        config.set_value("core", "autocrlf", "input")
 
     config.release()
 

--- a/scripts/upload-cache-to-github.py
+++ b/scripts/upload-cache-to-github.py
@@ -408,7 +408,6 @@ class Cache:
     config.set_value("user", "name", github.username)
     if sys.platform == "win32":
       config.set_value("core", "autocrlf", "input")
-
     config.release()
 
     if self.repo.is_dirty(untracked_files=True):

--- a/scripts/upload-cache-to-github.py
+++ b/scripts/upload-cache-to-github.py
@@ -407,7 +407,7 @@ class Cache:
     )
     config.set_value("user", "name", github.username)
     if sys.platform == "win32":
-        config.set_value("core", "autocrlf", "input")
+      config.set_value("core", "autocrlf", "input")
 
     config.release()
 


### PR DESCRIPTION
Fixes #1723.

This addresses an issue specific to Windows when using the Hunter cache, where it would often get stuck in a retry loop like so:

```
Pull failed: Cmd('git') failed due to: exit code(128)
  cmdline: git pull --allow-unrelated-histories --depth=1 --rebase --strategy=recursive --strategy-option=ours -v origin
  stderr: 'error: cannot pull with rebase: You have unstaged changes.
error: please commit or stash them.'
Retry #1 (of 10) after 0 seconds

Attempt #2
Pull failed: Cmd('git') failed due to: exit code(128)
  cmdline: git pull --allow-unrelated-histories --depth=1 --rebase --strategy=recursive --strategy-option=ours -v origin
  stderr: 'error: cannot pull with rebase: You have unstaged changes.
error: please commit or stash them.'
Retry #2 (of 10) after 15 seconds
...
```

We originally worked around the issue with a --global Git configuration on our servers, but have now extensively tested this targeted change to Hunter simultaneously with `git config --global --unset core.autocrlf`

<!--- Use this part of template for other type of changes. Remove the rest. -->
<!--- BEGIN -->

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **Yes, spaces instead of tabs, 2-space indent, no trailing whitespace**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **Yes, and we are not modifying CMake source files, only Python**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **Yes**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **Yes, two lines**

---
<!--- END -->
