### PR TITLE
Add older utf8 with header in default location

### DIFF
--- a/cmake/projects/utf8/hunter.cmake
+++ b/cmake/projects/utf8/hunter.cmake
@@ -19,6 +19,17 @@ hunter_add_version(
     438b70b0c6ee3f674e068ebbc19a4d04a5a4ca56
 )
 
+hunter_add_version(
+    PACKAGE_NAME
+    utf8
+    VERSION
+    2.3.4-p0
+    URL
+    "https://github.com/hunter-packages/utf8/archive/v2.3.4-p0.tar.gz"
+    SHA1
+    73116d453d4fb2ab4b46159095baeeb319f1ae28
+)
+
 hunter_pick_scheme(DEFAULT url_sha1_cmake)
 hunter_cacheable(utf8)
 hunter_download(PACKAGE_NAME utf8)


### PR DESCRIPTION
https://github.com/hunter-packages/utf8/commit/fd445050845b6bce1c94fd20dcce9afff38f8b44

As there was already a working release for our purposes in hunter-packages/utf8, can we simply make the older version available in hunter?