### PR TITLE
libusb: Improve test program and fix linking on macOS

### DIFF
--- a/cmake/modules/hunter_pkgconfig_export_target.cmake
+++ b/cmake/modules/hunter_pkgconfig_export_target.cmake
@@ -16,7 +16,7 @@ include(hunter_status_debug)
 # * x11
 # * x264
 # * xcb
-function(hunter_pkgconfig_export_target PKG_CONFIG_MODULE)
+function(hunter_pkgconfig_export_target PKG_CONFIG_MODULE PKG_GENERATE_SHARED)
   set(target_name "PkgConfig::${PKG_CONFIG_MODULE}")
   if(TARGET "${target_name}")
     return()
@@ -29,15 +29,25 @@ function(hunter_pkgconfig_export_target PKG_CONFIG_MODULE)
   endif()
   add_library("${target_name}" INTERFACE IMPORTED GLOBAL)
 
+  if(${PKG_GENERATE_SHARED})
+    set(PKG_CONFIG_PREFIX "${PKG_CONFIG_MODULE}")
+  else()
+    set(PKG_CONFIG_PREFIX "${PKG_CONFIG_MODULE}_STATIC")
+  endif()
+
+  hunter_status_debug(
+    "PKG_CONFIG_MODULE ${PKG_CONFIG_MODULE} Using prefix ${PKG_CONFIG_PREFIX}"
+  )
+
   # --- INTERFACE_INCLUDE_DIRECTORIES begin ---
   hunter_status_debug(
-      "PKG_CONFIG_MODULE ${PKG_CONFIG_MODULE} INCLUDE_DIRS: ${${PKG_CONFIG_MODULE}_INCLUDE_DIRS}"
+      "PKG_CONFIG_MODULE ${PKG_CONFIG_MODULE} INCLUDE_DIRS: ${${PKG_CONFIG_PREFIX}_INCLUDE_DIRS}"
   )
-  if(NOT "${${PKG_CONFIG_MODULE}_INCLUDE_DIRS}" STREQUAL "")
+  if(NOT "${${PKG_CONFIG_PREFIX}_INCLUDE_DIRS}" STREQUAL "")
     set_target_properties("${target_name}"
         PROPERTIES
           INTERFACE_INCLUDE_DIRECTORIES
-          "${${PKG_CONFIG_MODULE}_INCLUDE_DIRS}"
+          "${${PKG_CONFIG_PREFIX}_INCLUDE_DIRS}"
     )
   endif()
   # --- INTERFACE_INCLUDE_DIRECTORIES end ---
@@ -46,18 +56,18 @@ function(hunter_pkgconfig_export_target PKG_CONFIG_MODULE)
   set(link_libs)
 
   hunter_status_debug(
-      "PKG_CONFIG_MODULE ${PKG_CONFIG_MODULE} LDFLAGS: ${${PKG_CONFIG_MODULE}_LDFLAGS}"
+      "PKG_CONFIG_MODULE ${PKG_CONFIG_MODULE} LDFLAGS: ${${PKG_CONFIG_PREFIX}_LDFLAGS}"
   )
-  if(NOT "${${PKG_CONFIG_MODULE}_LDFLAGS}" STREQUAL "")
-    list(APPEND link_libs ${${PKG_CONFIG_MODULE}_LDFLAGS})
+  if(NOT "${${PKG_CONFIG_PREFIX}_LDFLAGS}" STREQUAL "")
+    list(APPEND link_libs ${${PKG_CONFIG_PREFIX}_LDFLAGS})
   endif()
 
   hunter_status_debug(
-      "PKG_CONFIG_MODULE ${PKG_CONFIG_MODULE} LDFLAGS_OTHER: ${${PKG_CONFIG_MODULE}_LDFLAGS_OTHER}"
+      "PKG_CONFIG_MODULE ${PKG_CONFIG_MODULE} LDFLAGS_OTHER: ${${PKG_CONFIG_PREFIX}_LDFLAGS_OTHER}"
   )
-  if(NOT "${${PKG_CONFIG_MODULE}_LDFLAGS_OTHER}" STREQUAL "")
+  if(NOT "${${PKG_CONFIG_PREFIX}_LDFLAGS_OTHER}" STREQUAL "")
     # turn "-framework;A;-framework;B" into "-framework A;-framework B"
-    string(REPLACE "-framework;" "-framework " ldflags_other "${${PKG_CONFIG_MODULE}_LDFLAGS_OTHER}")
+    string(REPLACE "-framework;" "-framework " ldflags_other "${${PKG_CONFIG_PREFIX}_LDFLAGS_OTHER}")
     list(APPEND link_libs ${ldflags_other})
   endif()
 
@@ -76,17 +86,17 @@ function(hunter_pkgconfig_export_target PKG_CONFIG_MODULE)
   set(compile_opts)
 
   hunter_status_debug(
-      "PKG_CONFIG_MODULE ${PKG_CONFIG_MODULE} CFLAGS: ${${PKG_CONFIG_MODULE}_CFLAGS}"
+      "PKG_CONFIG_MODULE ${PKG_CONFIG_MODULE} CFLAGS: ${${PKG_CONFIG_PREFIX}_CFLAGS}"
   )
-  if(NOT "${${PKG_CONFIG_MODULE}_CFLAGS}" STREQUAL "")
-    list(APPEND compile_opts ${${PKG_CONFIG_MODULE}_CFLAGS})
+  if(NOT "${${PKG_CONFIG_PREFIX}_CFLAGS}" STREQUAL "")
+    list(APPEND compile_opts ${${PKG_CONFIG_PREFIX}_CFLAGS})
   endif()
 
   hunter_status_debug(
-      "PKG_CONFIG_MODULE ${PKG_CONFIG_MODULE} CFLAGS_OTHER: ${${PKG_CONFIG_MODULE}_CFLAGS_OTHER}"
+      "PKG_CONFIG_MODULE ${PKG_CONFIG_MODULE} CFLAGS_OTHER: ${${PKG_CONFIG_PREFIX}_CFLAGS_OTHER}"
   )
-  if(NOT "${${PKG_CONFIG_MODULE}_CFLAGS_OTHER}" STREQUAL "")
-    list(APPEND compile_opts ${${PKG_CONFIG_MODULE}_CFLAGS_OTHER})
+  if(NOT "${${PKG_CONFIG_PREFIX}_CFLAGS_OTHER}" STREQUAL "")
+    list(APPEND compile_opts ${${PKG_CONFIG_PREFIX}_CFLAGS_OTHER})
   endif()
 
   if(NOT "${compile_opts}" STREQUAL "")
@@ -98,4 +108,3 @@ function(hunter_pkgconfig_export_target PKG_CONFIG_MODULE)
   endif()
   # --- INTERFACE_COMPILE_OPTIONS end ---
 endfunction()
-

--- a/cmake/projects/NASM/hunter.cmake
+++ b/cmake/projects/NASM/hunter.cmake
@@ -45,5 +45,4 @@ else()
   hunter_cacheable(NASM)
 endif()
 
-hunter_download(PACKAGE_NAME NASM)
-
+hunter_download(PACKAGE_NAME NASM PACKAGE_INTERNAL_DEPS_ID "1")

--- a/cmake/projects/PostgreSQL/hunter.cmake
+++ b/cmake/projects/PostgreSQL/hunter.cmake
@@ -56,7 +56,7 @@ hunter_pick_scheme(DEFAULT url_sha1_autotools)
 hunter_cacheable(PostgreSQL)
 hunter_download(
     PACKAGE_NAME PostgreSQL
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/pkgconfig/libecpg.pc"
     "lib/pkgconfig/libecpg_compat.pc"

--- a/cmake/projects/damageproto/hunter.cmake
+++ b/cmake/projects/damageproto/hunter.cmake
@@ -26,6 +26,6 @@ hunter_pick_scheme(DEFAULT url_sha1_autotools)
 hunter_cacheable(damageproto)
 hunter_download(
     PACKAGE_NAME damageproto
-    PACKAGE_INTERNAL_DEPS_ID "2"
+    PACKAGE_INTERNAL_DEPS_ID "3"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/pkgconfig/damageproto.pc"
 )

--- a/cmake/projects/dri2proto/hunter.cmake
+++ b/cmake/projects/dri2proto/hunter.cmake
@@ -26,6 +26,6 @@ hunter_pick_scheme(DEFAULT url_sha1_autotools)
 hunter_cacheable(dri2proto)
 hunter_download(
     PACKAGE_NAME dri2proto
-    PACKAGE_INTERNAL_DEPS_ID "2"
+    PACKAGE_INTERNAL_DEPS_ID "3"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/pkgconfig/dri2proto.pc"
 )

--- a/cmake/projects/dri3proto/hunter.cmake
+++ b/cmake/projects/dri3proto/hunter.cmake
@@ -26,6 +26,6 @@ hunter_pick_scheme(DEFAULT url_sha1_autotools)
 hunter_cacheable(dri3proto)
 hunter_download(
     PACKAGE_NAME dri3proto
-    PACKAGE_INTERNAL_DEPS_ID "2"
+    PACKAGE_INTERNAL_DEPS_ID "3"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/pkgconfig/dri3proto.pc"
 )

--- a/cmake/projects/drm/hunter.cmake
+++ b/cmake/projects/drm/hunter.cmake
@@ -48,7 +48,7 @@ hunter_cmake_args(
 hunter_cacheable(drm)
 hunter_download(
     PACKAGE_NAME drm
-    PACKAGE_INTERNAL_DEPS_ID "3"
+    PACKAGE_INTERNAL_DEPS_ID "4"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libdrm.la"
     "lib/libdrm_amdgpu.la"

--- a/cmake/projects/fixesproto/hunter.cmake
+++ b/cmake/projects/fixesproto/hunter.cmake
@@ -32,6 +32,6 @@ hunter_cmake_args(
 hunter_cacheable(fixesproto)
 hunter_download(
     PACKAGE_NAME fixesproto
-    PACKAGE_INTERNAL_DEPS_ID "2"
+    PACKAGE_INTERNAL_DEPS_ID "3"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/pkgconfig/fixesproto.pc"
 )

--- a/cmake/projects/geos/hunter.cmake
+++ b/cmake/projects/geos/hunter.cmake
@@ -23,5 +23,5 @@ hunter_configuration_types(geos CONFIGURATION_TYPES Release)
 hunter_pick_scheme(DEFAULT url_sha1_autotools)
 hunter_download(
     PACKAGE_NAME geos
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
 )

--- a/cmake/projects/glib/hunter.cmake
+++ b/cmake/projects/glib/hunter.cmake
@@ -35,7 +35,7 @@ hunter_pick_scheme(DEFAULT url_sha1_autotools)
 hunter_cacheable(glib)
 hunter_download(
     PACKAGE_NAME glib
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "bin/glib-gettextize"
     "lib/libgio-2.0.la"

--- a/cmake/projects/glproto/hunter.cmake
+++ b/cmake/projects/glproto/hunter.cmake
@@ -26,6 +26,6 @@ hunter_pick_scheme(DEFAULT url_sha1_autotools)
 hunter_cacheable(glproto)
 hunter_download(
     PACKAGE_NAME glproto
-    PACKAGE_INTERNAL_DEPS_ID "2"
+    PACKAGE_INTERNAL_DEPS_ID "3"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/pkgconfig/glproto.pc"
 )

--- a/cmake/projects/gst_plugins_bad/hunter.cmake
+++ b/cmake/projects/gst_plugins_bad/hunter.cmake
@@ -53,7 +53,7 @@ hunter_cacheable(gst_plugins_bad)
 hunter_download(
     PACKAGE_NAME
     gst_plugins_bad
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/gstreamer-1.0/libgstaccurip.la"
     "lib/gstreamer-1.0/libgstadpcmdec.la"

--- a/cmake/projects/gst_plugins_base/hunter.cmake
+++ b/cmake/projects/gst_plugins_base/hunter.cmake
@@ -57,7 +57,7 @@ hunter_cacheable(gst_plugins_base)
 hunter_download(
     PACKAGE_NAME
     gst_plugins_base
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/gstreamer-1.0/libgstadder.la"
     "lib/gstreamer-1.0/libgstapp.la"

--- a/cmake/projects/gst_plugins_good/hunter.cmake
+++ b/cmake/projects/gst_plugins_good/hunter.cmake
@@ -35,7 +35,7 @@ hunter_cacheable(gst_plugins_good)
 hunter_download(
     PACKAGE_NAME
     gst_plugins_good
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/gstreamer-1.0/libgstalaw.la"
     "lib/gstreamer-1.0/libgstalpha.la"

--- a/cmake/projects/gst_plugins_ugly/hunter.cmake
+++ b/cmake/projects/gst_plugins_ugly/hunter.cmake
@@ -35,7 +35,7 @@ hunter_cacheable(gst_plugins_ugly)
 hunter_download(
     PACKAGE_NAME
     gst_plugins_ugly
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/gstreamer-1.0/libgstasf.la"
     "lib/gstreamer-1.0/libgstdvdlpcmdec.la"

--- a/cmake/projects/gstreamer/hunter.cmake
+++ b/cmake/projects/gstreamer/hunter.cmake
@@ -35,7 +35,7 @@ hunter_cmake_args(
 hunter_cacheable(gstreamer)
 hunter_download(
     PACKAGE_NAME gstreamer
-    PACKAGE_INTERNAL_DEPS_ID "3"
+    PACKAGE_INTERNAL_DEPS_ID "4"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/gstreamer-1.0/libgstcoreelements.la"
     "lib/gstreamer-1.0/libgstcoretracers.la"

--- a/cmake/projects/ice/hunter.cmake
+++ b/cmake/projects/ice/hunter.cmake
@@ -32,7 +32,7 @@ hunter_cmake_args(
 hunter_cacheable(ice)
 hunter_download(
     PACKAGE_NAME ice
-    PACKAGE_INTERNAL_DEPS_ID "3"
+    PACKAGE_INTERNAL_DEPS_ID "4"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libICE.la"
     "lib/pkgconfig/ice.pc"

--- a/cmake/projects/inputproto/hunter.cmake
+++ b/cmake/projects/inputproto/hunter.cmake
@@ -32,6 +32,6 @@ hunter_cmake_args(
 )
 hunter_download(
     PACKAGE_NAME inputproto
-    PACKAGE_INTERNAL_DEPS_ID "2"
+    PACKAGE_INTERNAL_DEPS_ID "3"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/pkgconfig/inputproto.pc"
 )

--- a/cmake/projects/intltool/hunter.cmake
+++ b/cmake/projects/intltool/hunter.cmake
@@ -23,5 +23,5 @@ hunter_configuration_types(intltool CONFIGURATION_TYPES Release)
 hunter_pick_scheme(DEFAULT url_sha1_autotools)
 hunter_download(
     PACKAGE_NAME intltool
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
 )

--- a/cmake/projects/kbproto/hunter.cmake
+++ b/cmake/projects/kbproto/hunter.cmake
@@ -32,6 +32,6 @@ hunter_cmake_args(
 hunter_cacheable(kbproto)
 hunter_download(
     PACKAGE_NAME kbproto
-    PACKAGE_INTERNAL_DEPS_ID "2"
+    PACKAGE_INTERNAL_DEPS_ID "3"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/pkgconfig/kbproto.pc"
 )

--- a/cmake/projects/libdaemon/hunter.cmake
+++ b/cmake/projects/libdaemon/hunter.cmake
@@ -23,5 +23,5 @@ hunter_configuration_types(libdaemon CONFIGURATION_TYPES Release)
 hunter_pick_scheme(DEFAULT url_sha1_autotools)
 hunter_download(
     PACKAGE_NAME libdaemon
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
 )

--- a/cmake/projects/libffi/hunter.cmake
+++ b/cmake/projects/libffi/hunter.cmake
@@ -33,7 +33,7 @@ hunter_cmake_args(
 hunter_cacheable(libffi)
 hunter_download(
     PACKAGE_NAME libffi
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libffi.la"
     "lib/pkgconfig/libffi.pc"

--- a/cmake/projects/libpcre/hunter.cmake
+++ b/cmake/projects/libpcre/hunter.cmake
@@ -34,7 +34,7 @@ hunter_cmake_args(
 hunter_cacheable(libpcre)
 hunter_download(
     PACKAGE_NAME libpcre
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libpcre.la"
     "lib/libpcrecpp.la"

--- a/cmake/projects/libusb/hunter.cmake
+++ b/cmake/projects/libusb/hunter.cmake
@@ -31,7 +31,7 @@ hunter_configuration_types(libusb CONFIGURATION_TYPES Release)
 hunter_pick_scheme(DEFAULT url_sha1_autogen_autotools)
 hunter_cacheable(libusb)
 hunter_download(PACKAGE_NAME libusb
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     lib/pkgconfig/libusb-1.0.pc
 )

--- a/cmake/projects/libxml2/hunter.cmake
+++ b/cmake/projects/libxml2/hunter.cmake
@@ -67,6 +67,6 @@ hunter_cacheable(libxml2)
 
 hunter_download(
     PACKAGE_NAME libxml2
-    PACKAGE_INTERNAL_DEPS_ID "7"
+    PACKAGE_INTERNAL_DEPS_ID "8"
     ${_libxml_unrelocatable_text_files}
 )

--- a/cmake/projects/odb/hunter.cmake
+++ b/cmake/projects/odb/hunter.cmake
@@ -25,7 +25,7 @@ hunter_pick_scheme(DEFAULT url_sha1_autotools)
 hunter_cacheable(odb)
 hunter_download(
     PACKAGE_NAME odb
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libodb.la"
     "lib/pkgconfig/libodb.pc"

--- a/cmake/projects/pciaccess/hunter.cmake
+++ b/cmake/projects/pciaccess/hunter.cmake
@@ -26,7 +26,7 @@ hunter_pick_scheme(DEFAULT url_sha1_autotools)
 hunter_cacheable(pciaccess)
 hunter_download(
     PACKAGE_NAME pciaccess
-    PACKAGE_INTERNAL_DEPS_ID "3"
+    PACKAGE_INTERNAL_DEPS_ID "4"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libpciaccess.la"
     "lib/pkgconfig/pciaccess.pc"

--- a/cmake/projects/presentproto/hunter.cmake
+++ b/cmake/projects/presentproto/hunter.cmake
@@ -26,6 +26,6 @@ hunter_pick_scheme(DEFAULT url_sha1_autotools)
 hunter_cacheable(presentproto)
 hunter_download(
     PACKAGE_NAME presentproto
-    PACKAGE_INTERNAL_DEPS_ID "2"
+    PACKAGE_INTERNAL_DEPS_ID "3"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/pkgconfig/presentproto.pc"
 )

--- a/cmake/projects/pthread-stubs/hunter.cmake
+++ b/cmake/projects/pthread-stubs/hunter.cmake
@@ -32,6 +32,6 @@ hunter_cmake_args(
 )
 hunter_download(
     PACKAGE_NAME pthread-stubs
-    PACKAGE_INTERNAL_DEPS_ID "2"
+    PACKAGE_INTERNAL_DEPS_ID "3"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/pkgconfig/pthread-stubs.pc"
 )

--- a/cmake/projects/randrproto/hunter.cmake
+++ b/cmake/projects/randrproto/hunter.cmake
@@ -36,7 +36,7 @@ hunter_cmake_args(
 hunter_cacheable(randrproto)
 hunter_download(
     PACKAGE_NAME randrproto
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/pkgconfig/randrproto.pc"
 )

--- a/cmake/projects/renderproto/hunter.cmake
+++ b/cmake/projects/renderproto/hunter.cmake
@@ -32,6 +32,6 @@ hunter_cmake_args(
 hunter_cacheable(renderproto)
 hunter_download(
     PACKAGE_NAME renderproto
-    PACKAGE_INTERNAL_DEPS_ID "2"
+    PACKAGE_INTERNAL_DEPS_ID "3"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/pkgconfig/renderproto.pc"
 )

--- a/cmake/projects/sm/hunter.cmake
+++ b/cmake/projects/sm/hunter.cmake
@@ -37,7 +37,7 @@ hunter_cmake_args(
 hunter_cacheable(sm)
 hunter_download(
     PACKAGE_NAME sm
-    PACKAGE_INTERNAL_DEPS_ID "3"
+    PACKAGE_INTERNAL_DEPS_ID "4"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libSM.la"
     "lib/pkgconfig/sm.pc"

--- a/cmake/projects/tcl/hunter.cmake
+++ b/cmake/projects/tcl/hunter.cmake
@@ -18,4 +18,6 @@ hunter_add_version(
 hunter_configuration_types(tcl CONFIGURATION_TYPES Release)
 hunter_pick_scheme(DEFAULT url_sha1_tcl_autotools)
 hunter_cacheable(tcl)
-hunter_download(PACKAGE_NAME tcl)
+hunter_download(PACKAGE_NAME tcl
+    PACKAGE_INTERNAL_DEPS_ID "1"
+)

--- a/cmake/projects/tcl/schemes/url_sha1_tcl_autotools.cmake.in
+++ b/cmake/projects/tcl/schemes/url_sha1_tcl_autotools.cmake.in
@@ -89,9 +89,12 @@ if(NOT default_pkgconfig)
   set(DEPENDS_ON_PACKAGES ${DEPENDS_ON_PKGCONFIGS})
 endif()
 
+set(PKG_GENERATE_SHARED "${BUILD_SHARED_LIBS}")
+
 foreach(PKG_CONFIG_MODULE ${PKGCONFIG_EXPORT_TARGETS})
   # Use:
   # * DEPENDS_ON_PACKAGES
+  # * PKG_GENERATE_SHARED
   configure_file(
       "@HUNTER_GLOBAL_SCRIPT_DIR@/pkgconfig-export-targets.cmake.in"
       "@HUNTER_PACKAGE_INSTALL_PREFIX@/lib/cmake/${PKG_CONFIG_MODULE}/${PKG_CONFIG_MODULE}Config.cmake"

--- a/cmake/projects/util_linux/hunter.cmake
+++ b/cmake/projects/util_linux/hunter.cmake
@@ -34,7 +34,7 @@ hunter_cmake_args(
 hunter_cacheable(util_linux)
 hunter_download(
     PACKAGE_NAME util_linux
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libblkid.la"
     "lib/libfdisk.la"

--- a/cmake/projects/x11/hunter.cmake
+++ b/cmake/projects/x11/hunter.cmake
@@ -41,7 +41,7 @@ hunter_cmake_args(
 hunter_cacheable(x11)
 hunter_download(
     PACKAGE_NAME x11
-    PACKAGE_INTERNAL_DEPS_ID "5"
+    PACKAGE_INTERNAL_DEPS_ID "6"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libX11-xcb.la"
     "lib/libX11.la"

--- a/cmake/projects/x264/hunter.cmake
+++ b/cmake/projects/x264/hunter.cmake
@@ -25,7 +25,6 @@ hunter_cmake_args(x264 CMAKE_ARGS PKGCONFIG_EXPORT_TARGETS=x264)
 hunter_cacheable(x264)
 hunter_download(
     PACKAGE_NAME x264
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/pkgconfig/x264.pc"
 )
-

--- a/cmake/projects/x264/schemes/url_sha1_x264.cmake.in
+++ b/cmake/projects/x264/schemes/url_sha1_x264.cmake.in
@@ -341,6 +341,8 @@ else()
   )
 endif()
 
+set(PKG_GENERATE_SHARED "${BUILD_SHARED_LIBS}")
+
 foreach(PKG_CONFIG_MODULE ${PKGCONFIG_EXPORT_TARGETS})
   configure_file(
       "@HUNTER_GLOBAL_SCRIPT_DIR@/pkgconfig-export-targets.cmake.in"

--- a/cmake/projects/xau/hunter.cmake
+++ b/cmake/projects/xau/hunter.cmake
@@ -37,6 +37,6 @@ hunter_cmake_args(
 hunter_cacheable(xau)
 hunter_download(
     PACKAGE_NAME xau
-    PACKAGE_INTERNAL_DEPS_ID "6"
+    PACKAGE_INTERNAL_DEPS_ID "7"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/libXau.la;lib/pkgconfig/xau.pc"
 )

--- a/cmake/projects/xcb-proto/hunter.cmake
+++ b/cmake/projects/xcb-proto/hunter.cmake
@@ -55,6 +55,6 @@ hunter_cmake_args(
 hunter_cacheable(xcb-proto)
 hunter_download(
     PACKAGE_NAME xcb-proto
-    PACKAGE_INTERNAL_DEPS_ID "2"
+    PACKAGE_INTERNAL_DEPS_ID "3"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/pkgconfig/xcb-proto.pc"
 )

--- a/cmake/projects/xcb/hunter.cmake
+++ b/cmake/projects/xcb/hunter.cmake
@@ -63,6 +63,6 @@ hunter_pick_scheme(DEFAULT xcb)
 hunter_cacheable(xcb)
 hunter_download(
     PACKAGE_NAME xcb
-    PACKAGE_INTERNAL_DEPS_ID "4"
+    PACKAGE_INTERNAL_DEPS_ID "5"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "${_xcb_text_files}"
 )

--- a/cmake/projects/xcb/schemes/xcb.cmake.in
+++ b/cmake/projects/xcb/schemes/xcb.cmake.in
@@ -69,9 +69,12 @@ hunter_autotools_project(
 
 set(PKG_CONFIG_MODULE xcb)
 
+set(PKG_GENERATE_SHARED "${BUILD_SHARED_LIBS}")
+
 # Use:
 # * PKG_CONFIG_MODULE
 # * DEPENDS_ON_PACKAGES
+# * PKG_GENERATE_SHARED
 configure_file(
     "@HUNTER_GLOBAL_SCRIPT_DIR@/pkgconfig-export-targets.cmake.in"
     "@HUNTER_PACKAGE_INSTALL_PREFIX@/lib/cmake/${PKG_CONFIG_MODULE}/${PKG_CONFIG_MODULE}Config.cmake"

--- a/cmake/projects/xcursor/hunter.cmake
+++ b/cmake/projects/xcursor/hunter.cmake
@@ -40,7 +40,7 @@ hunter_cmake_args(
 hunter_cacheable(xcursor)
 hunter_download(
     PACKAGE_NAME xcursor
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libXcursor.la"
     "lib/pkgconfig/xcursor.pc"

--- a/cmake/projects/xdamage/hunter.cmake
+++ b/cmake/projects/xdamage/hunter.cmake
@@ -39,7 +39,7 @@ hunter_cmake_args(
 )
 hunter_download(
     PACKAGE_NAME xdamage
-    PACKAGE_INTERNAL_DEPS_ID "3"
+    PACKAGE_INTERNAL_DEPS_ID "4"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/pkgconfig/xdamage.pc"
     "lib/libXdamage.la"

--- a/cmake/projects/xext/hunter.cmake
+++ b/cmake/projects/xext/hunter.cmake
@@ -38,7 +38,7 @@ hunter_cmake_args(
 hunter_cacheable(xext)
 hunter_download(
     PACKAGE_NAME xext
-    PACKAGE_INTERNAL_DEPS_ID "3"
+    PACKAGE_INTERNAL_DEPS_ID "4"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libXext.la"
     "lib/pkgconfig/xext.pc"

--- a/cmake/projects/xextproto/hunter.cmake
+++ b/cmake/projects/xextproto/hunter.cmake
@@ -32,6 +32,6 @@ hunter_cmake_args(
 hunter_cacheable(xextproto)
 hunter_download(
     PACKAGE_NAME xextproto
-    PACKAGE_INTERNAL_DEPS_ID "2"
+    PACKAGE_INTERNAL_DEPS_ID "3"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/pkgconfig/xextproto.pc"
 )

--- a/cmake/projects/xf86vidmodeproto/hunter.cmake
+++ b/cmake/projects/xf86vidmodeproto/hunter.cmake
@@ -36,7 +36,7 @@ hunter_cmake_args(
 hunter_cacheable(xf86vidmodeproto)
 hunter_download(
     PACKAGE_NAME xf86vidmodeproto
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/pkgconfig/xf86vidmodeproto.pc"
 )

--- a/cmake/projects/xfixes/hunter.cmake
+++ b/cmake/projects/xfixes/hunter.cmake
@@ -40,7 +40,7 @@ hunter_cmake_args(
 hunter_cacheable(xfixes)
 hunter_download(
     PACKAGE_NAME xfixes
-    PACKAGE_INTERNAL_DEPS_ID "3"
+    PACKAGE_INTERNAL_DEPS_ID "4"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libXfixes.la"
     "lib/pkgconfig/xfixes.pc"

--- a/cmake/projects/xi/hunter.cmake
+++ b/cmake/projects/xi/hunter.cmake
@@ -45,6 +45,7 @@ hunter_cmake_args(
 hunter_cacheable(xi)
 hunter_download(
     PACKAGE_NAME xi
+    PACKAGE_INTERNAL_DEPS_ID "1"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libXi.la"
     "lib/pkgconfig/xi.pc"

--- a/cmake/projects/xinerama/hunter.cmake
+++ b/cmake/projects/xinerama/hunter.cmake
@@ -39,7 +39,7 @@ hunter_cmake_args(
 hunter_cacheable(xinerama)
 hunter_download(
     PACKAGE_NAME xinerama
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libXinerama.la"
     "lib/pkgconfig/xinerama.pc"

--- a/cmake/projects/xineramaproto/hunter.cmake
+++ b/cmake/projects/xineramaproto/hunter.cmake
@@ -36,7 +36,7 @@ hunter_cmake_args(
 hunter_cacheable(xineramaproto)
 hunter_download(
     PACKAGE_NAME xineramaproto
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/pkgconfig/xineramaproto.pc"
 )

--- a/cmake/projects/xorg-macros/hunter.cmake
+++ b/cmake/projects/xorg-macros/hunter.cmake
@@ -32,6 +32,6 @@ hunter_cmake_args(
 )
 hunter_download(
     PACKAGE_NAME xorg-macros
-    PACKAGE_INTERNAL_DEPS_ID "2"
+    PACKAGE_INTERNAL_DEPS_ID "3"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "share/pkgconfig/xorg-macros.pc"
 )

--- a/cmake/projects/xproto/hunter.cmake
+++ b/cmake/projects/xproto/hunter.cmake
@@ -33,6 +33,6 @@ hunter_cmake_args(
 hunter_cacheable(xproto)
 hunter_download(
     PACKAGE_NAME xproto
-    PACKAGE_INTERNAL_DEPS_ID "3"
+    PACKAGE_INTERNAL_DEPS_ID "4"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/pkgconfig/xproto.pc"
 )

--- a/cmake/projects/xrandr/hunter.cmake
+++ b/cmake/projects/xrandr/hunter.cmake
@@ -41,7 +41,7 @@ hunter_cmake_args(
 hunter_cacheable(xrandr)
 hunter_download(
     PACKAGE_NAME xrandr
-    PACKAGE_INTERNAL_DEPS_ID "2"
+    PACKAGE_INTERNAL_DEPS_ID "3"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/pkgconfig/xrandr.pc"
     "lib/libXrandr.la"

--- a/cmake/projects/xrender/hunter.cmake
+++ b/cmake/projects/xrender/hunter.cmake
@@ -37,7 +37,7 @@ hunter_cmake_args(
 hunter_cacheable(xrender)
 hunter_download(
     PACKAGE_NAME xrender
-    PACKAGE_INTERNAL_DEPS_ID "3"
+    PACKAGE_INTERNAL_DEPS_ID "4"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libXrender.la"
     "lib/pkgconfig/xrender.pc"

--- a/cmake/projects/xshmfence/hunter.cmake
+++ b/cmake/projects/xshmfence/hunter.cmake
@@ -46,7 +46,7 @@ hunter_cmake_args(
 hunter_cacheable(xshmfence)
 hunter_download(
     PACKAGE_NAME xshmfence
-    PACKAGE_INTERNAL_DEPS_ID "3"
+    PACKAGE_INTERNAL_DEPS_ID "4"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libxshmfence.la"
     "lib/pkgconfig/xshmfence.pc"

--- a/cmake/projects/xtrans/hunter.cmake
+++ b/cmake/projects/xtrans/hunter.cmake
@@ -32,6 +32,6 @@ hunter_cmake_args(
 )
 hunter_download(
     PACKAGE_NAME xtrans
-    PACKAGE_INTERNAL_DEPS_ID "2"
+    PACKAGE_INTERNAL_DEPS_ID "3"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "share/pkgconfig/xtrans.pc"
 )

--- a/cmake/projects/xxf86vm/hunter.cmake
+++ b/cmake/projects/xxf86vm/hunter.cmake
@@ -41,7 +41,7 @@ hunter_cmake_args(
 hunter_cacheable(xxf86vm)
 hunter_download(
     PACKAGE_NAME xxf86vm
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libXxf86vm.la"
     "lib/pkgconfig/xxf86vm.pc"

--- a/cmake/schemes/url_sha1_autogen_autotools.cmake.in
+++ b/cmake/schemes/url_sha1_autogen_autotools.cmake.in
@@ -62,9 +62,12 @@ if(NOT default_pkgconfig)
   set(DEPENDS_ON_PACKAGES ${DEPENDS_ON_PKGCONFIGS})
 endif()
 
+set(PKG_GENERATE_SHARED "${BUILD_SHARED_LIBS}")
+
 foreach(PKG_CONFIG_MODULE ${PKGCONFIG_EXPORT_TARGETS})
   # Use:
   # * DEPENDS_ON_PACKAGES
+  # * PKG_GENERATE_SHARED
   configure_file(
       "@HUNTER_GLOBAL_SCRIPT_DIR@/pkgconfig-export-targets.cmake.in"
       "@HUNTER_PACKAGE_INSTALL_PREFIX@/lib/cmake/${PKG_CONFIG_MODULE}/${PKG_CONFIG_MODULE}Config.cmake"

--- a/cmake/schemes/url_sha1_autotools.cmake.in
+++ b/cmake/schemes/url_sha1_autotools.cmake.in
@@ -64,9 +64,12 @@ if(NOT default_pkgconfig)
   set(DEPENDS_ON_PACKAGES ${DEPENDS_ON_PKGCONFIGS})
 endif()
 
+set(PKG_GENERATE_SHARED "${BUILD_SHARED_LIBS}")
+
 foreach(PKG_CONFIG_MODULE ${PKGCONFIG_EXPORT_TARGETS})
   # Use:
   # * DEPENDS_ON_PACKAGES
+  # * PKG_GENERATE_SHARED
   configure_file(
       "@HUNTER_GLOBAL_SCRIPT_DIR@/pkgconfig-export-targets.cmake.in"
       "@HUNTER_PACKAGE_INSTALL_PREFIX@/lib/cmake/${PKG_CONFIG_MODULE}/${PKG_CONFIG_MODULE}Config.cmake"

--- a/examples/libusb/boo.cpp
+++ b/examples/libusb/boo.cpp
@@ -1,4 +1,20 @@
 #include <libusb.h>
 
 int main() {
+    libusb_device **devs;
+    int r;
+    ssize_t cnt;
+
+    r = libusb_init(NULL);
+    if (r < 0)
+        return r;
+
+    cnt = libusb_get_device_list(NULL, &devs);
+    if (cnt < 0)
+        return (int) cnt;
+
+    libusb_free_device_list(devs, 1);
+
+    libusb_exit(NULL);
+    return 0;
 }

--- a/examples/x264/CMakeLists.txt
+++ b/examples/x264/CMakeLists.txt
@@ -1,11 +1,10 @@
 # Copyright (c) 2017, Alexandre Pretyman
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.2)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate
 include("../common.cmake")
-include(hunter_pkgconfig_export_target)
 
 project(x264-example)
 

--- a/scripts/pkgconfig-export-targets.cmake.in
+++ b/scripts/pkgconfig-export-targets.cmake.in
@@ -7,7 +7,7 @@
 
 include(hunter_pkgconfig_export_target)
 
-hunter_pkgconfig_export_target("@PKG_CONFIG_MODULE@")
+hunter_pkgconfig_export_target("@PKG_CONFIG_MODULE@" "@PKG_GENERATE_SHARED@")
 
 foreach(_hunter_deps @DEPENDS_ON_PACKAGES@)
   find_package("${_hunter_deps}" CONFIG REQUIRED)


### PR DESCRIPTION
* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

Here are the Travis and Appveyor:
https://travis-ci.org/hjmallon/hunter/builds/523397197?utm_source=github_status&utm_medium=notification
https://ci.appveyor.com/project/hjmallon/hunter/builds/24035892

---

`pkgconfig --static` is required to link the correct libraries for libusb on macOS. This isn't shown in testing as the test program has an empty `main`.

I have added a new main adapted from `libusb` example and added functionality to use pkgconfig STATIC variables if any library is being linked statically (I believe this should fall through to normal variables in almost all cases).
