### PR TITLE
Reduce required version of gcc to 4.8 per latest project README

### DIFF
--- a/cmake/projects/nlohmann_json/hunter.cmake
+++ b/cmake/projects/nlohmann_json/hunter.cmake
@@ -10,8 +10,8 @@ include(hunter_status_debug)
 
 # See https://github.com/nlohmann/json#supported-compilers
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9")
-    hunter_report_broken_package("The nlohmann_json package requires GCC 4.9 or newer.")
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.8")
+    hunter_report_broken_package("The nlohmann_json package requires GCC 4.8 or newer.")
   endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "3.4")


### PR DESCRIPTION
* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

Relax gcc compiler requirements -- the package currently works with GCC 4.8 or newer. 

https://github.com/nlohmann/json#supported-compilers

> * GCC 4.8 - 9.0 (and possibly later)

Updating this for the latest version seems to be the right thing to do.  It might be the case that older versions had different requirements.
