### PR TITLE
Fixed libogg build on systems having lib64 set as the CMAKE_INSTALL_LIBDIR

### DIFF
--- a/cmake/projects/libogg/hunter.cmake
+++ b/cmake/projects/libogg/hunter.cmake
@@ -2,6 +2,7 @@ include(hunter_add_version)
 include(hunter_cacheable)
 include(hunter_download)
 include(hunter_pick_scheme)
+include(GNUInstallDirs)
 
 hunter_add_version(
 	PACKAGE_NAME
@@ -31,5 +32,5 @@ hunter_download(
     PACKAGE_NAME
     libogg
     PACKAGE_UNRELOCATABLE_TEXT_FILES
-    "lib/pkgconfig/ogg.pc"
+    "${CMAKE_INSTALL_LIBDIR}/pkgconfig/ogg.pc"
 )

--- a/cmake/projects/libogg/hunter.cmake
+++ b/cmake/projects/libogg/hunter.cmake
@@ -33,4 +33,5 @@ hunter_download(
     libogg
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "${CMAKE_INSTALL_LIBDIR}/pkgconfig/ogg.pc"
+    PACKAGE_INTERNAL_DEPS_ID "1"
 )


### PR DESCRIPTION
* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**


