### PR TITLE
Fixed gstreamer build on systems having lib64 set as the CMAKE_INSTALL_LIBDIR

### DIFF
--- a/cmake/projects/gstreamer/hunter.cmake
+++ b/cmake/projects/gstreamer/hunter.cmake
@@ -9,6 +9,7 @@ include(hunter_cmake_args)
 include(hunter_configuration_types)
 include(hunter_download)
 include(hunter_pick_scheme)
+include(GNUInstallDirs)
 
 hunter_add_version(
     PACKAGE_NAME
@@ -37,16 +38,16 @@ hunter_download(
     PACKAGE_NAME gstreamer
     PACKAGE_INTERNAL_DEPS_ID "4"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
-    "lib/gstreamer-1.0/libgstcoreelements.la"
-    "lib/gstreamer-1.0/libgstcoretracers.la"
-    "lib/libgstbase-1.0.la"
-    "lib/libgstcheck-1.0.la"
-    "lib/libgstcontroller-1.0.la"
-    "lib/libgstnet-1.0.la"
-    "lib/libgstreamer-1.0.la"
-    "lib/pkgconfig/gstreamer-1.0.pc"
-    "lib/pkgconfig/gstreamer-base-1.0.pc"
-    "lib/pkgconfig/gstreamer-check-1.0.pc"
-    "lib/pkgconfig/gstreamer-controller-1.0.pc"
-    "lib/pkgconfig/gstreamer-net-1.0.pc"
+    "${CMAKE_INSTALL_LIBDIR}/gstreamer-1.0/libgstcoreelements.la"
+    "${CMAKE_INSTALL_LIBDIR}/gstreamer-1.0/libgstcoretracers.la"
+    "${CMAKE_INSTALL_LIBDIR}/libgstbase-1.0.la"
+    "${CMAKE_INSTALL_LIBDIR}/libgstcheck-1.0.la"
+    "${CMAKE_INSTALL_LIBDIR}/libgstcontroller-1.0.la"
+    "${CMAKE_INSTALL_LIBDIR}/libgstnet-1.0.la"
+    "${CMAKE_INSTALL_LIBDIR}/libgstreamer-1.0.la"
+    "${CMAKE_INSTALL_LIBDIR}/pkgconfig/gstreamer-1.0.pc"
+    "${CMAKE_INSTALL_LIBDIR}/pkgconfig/gstreamer-base-1.0.pc"
+    "${CMAKE_INSTALL_LIBDIR}/pkgconfig/gstreamer-check-1.0.pc"
+    "${CMAKE_INSTALL_LIBDIR}/pkgconfig/gstreamer-controller-1.0.pc"
+    "${CMAKE_INSTALL_LIBDIR}/pkgconfig/gstreamer-net-1.0.pc"
 )


### PR DESCRIPTION
* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**
