### PR TITLE
Add support for PACKAGE_UNRELOCATABLE_TEXT_FILES_OPTIONAL

### DIFF
--- a/cmake/modules/hunter_download.cmake
+++ b/cmake/modules/hunter_download.cmake
@@ -31,13 +31,14 @@ include(hunter_user_error)
 # Note: 'hunter_find_licenses' should be called before each return point
 function(hunter_download)
   set(one PACKAGE_NAME PACKAGE_COMPONENT PACKAGE_INTERNAL_DEPS_ID)
-  set(multiple PACKAGE_UNRELOCATABLE_TEXT_FILES)
+  set(multiple PACKAGE_UNRELOCATABLE_TEXT_FILES PACKAGE_UNRELOCATABLE_TEXT_FILES_OPTIONAL)
 
   cmake_parse_arguments(HUNTER "" "${one}" "${multiple}" ${ARGV})
   # -> HUNTER_PACKAGE_NAME
   # -> HUNTER_PACKAGE_COMPONENT
   # -> HUNTER_PACKAGE_INTERNAL_DEPS_ID
   # -> HUNTER_PACKAGE_UNRELOCATABLE_TEXT_FILES
+  # -> HUNTER_PACKAGE_UNRELOCATABLE_TEXT_FILES_OPTIONAL
 
   hunter_assert_empty_string("${HUNTER_UNPARSED_ARGUMENTS}")
 
@@ -100,7 +101,7 @@ function(hunter_download)
 
   hunter_get_cacheable(
       PACKAGE "${package}"
-      UNRELOCATABLE "${HUNTER_PACKAGE_UNRELOCATABLE_TEXT_FILES}"
+      UNRELOCATABLE "${HUNTER_PACKAGE_UNRELOCATABLE_TEXT_FILES};${HUNTER_PACKAGE_UNRELOCATABLE_TEXT_FILES_OPTIONAL}"
       OUT HUNTER_PACKAGE_CACHEABLE
   )
 

--- a/cmake/projects/gst_plugins_bad/hunter.cmake
+++ b/cmake/projects/gst_plugins_bad/hunter.cmake
@@ -54,7 +54,7 @@ hunter_download(
     PACKAGE_NAME
     gst_plugins_bad
     PACKAGE_INTERNAL_DEPS_ID "2"
-    PACKAGE_UNRELOCATABLE_TEXT_FILES
+    PACKAGE_UNRELOCATABLE_TEXT_FILES_OPTIONAL
     "lib/gstreamer-1.0/libgstaccurip.la"
     "lib/gstreamer-1.0/libgstadpcmdec.la"
     "lib/gstreamer-1.0/libgstadpcmenc.la"

--- a/cmake/projects/gst_plugins_base/hunter.cmake
+++ b/cmake/projects/gst_plugins_base/hunter.cmake
@@ -58,7 +58,7 @@ hunter_download(
     PACKAGE_NAME
     gst_plugins_base
     PACKAGE_INTERNAL_DEPS_ID "2"
-    PACKAGE_UNRELOCATABLE_TEXT_FILES
+    PACKAGE_UNRELOCATABLE_TEXT_FILES_OPTIONAL
     "lib/gstreamer-1.0/libgstadder.la"
     "lib/gstreamer-1.0/libgstapp.la"
     "lib/gstreamer-1.0/libgstaudioconvert.la"

--- a/cmake/projects/gst_plugins_good/hunter.cmake
+++ b/cmake/projects/gst_plugins_good/hunter.cmake
@@ -36,7 +36,7 @@ hunter_download(
     PACKAGE_NAME
     gst_plugins_good
     PACKAGE_INTERNAL_DEPS_ID "2"
-    PACKAGE_UNRELOCATABLE_TEXT_FILES
+    PACKAGE_UNRELOCATABLE_TEXT_FILES_OPTIONAL
     "lib/gstreamer-1.0/libgstalaw.la"
     "lib/gstreamer-1.0/libgstalpha.la"
     "lib/gstreamer-1.0/libgstalphacolor.la"

--- a/cmake/projects/gst_plugins_ugly/hunter.cmake
+++ b/cmake/projects/gst_plugins_ugly/hunter.cmake
@@ -36,7 +36,7 @@ hunter_download(
     PACKAGE_NAME
     gst_plugins_ugly
     PACKAGE_INTERNAL_DEPS_ID "2"
-    PACKAGE_UNRELOCATABLE_TEXT_FILES
+    PACKAGE_UNRELOCATABLE_TEXT_FILES_OPTIONAL
     "lib/gstreamer-1.0/libgstasf.la"
     "lib/gstreamer-1.0/libgstdvdlpcmdec.la"
     "lib/gstreamer-1.0/libgstdvdsub.la"

--- a/cmake/projects/gstreamer/hunter.cmake
+++ b/cmake/projects/gstreamer/hunter.cmake
@@ -36,7 +36,7 @@ hunter_cacheable(gstreamer)
 hunter_download(
     PACKAGE_NAME gstreamer
     PACKAGE_INTERNAL_DEPS_ID "4"
-    PACKAGE_UNRELOCATABLE_TEXT_FILES
+    PACKAGE_UNRELOCATABLE_TEXT_FILES_OPTIONAL
     "lib/gstreamer-1.0/libgstcoreelements.la"
     "lib/gstreamer-1.0/libgstcoretracers.la"
     "lib/libgstbase-1.0.la"


### PR DESCRIPTION
<!--- Use this part of template for other type of changes. Remove the rest. -->
<!--- BEGIN -->

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

---

Implement support for PACKAGE_UNRELOCATABLE_TEXT_FILES_OPTIONAL, so that packages where the set of output files is dependent on user serviceable parts (CMAKE_ARGS) will not fail if the full set of files that must be patched is not present. Works exactly like PACKAGE_UNRELOCATABLE_TEXT_FILES otherwise.

<!--- END -->
