### PR TITLE
add note about HUNTER_DOWNLOAD_SERVER behaviour

### DIFF
--- a/docs/reference/user-variables.rst
+++ b/docs/reference/user-variables.rst
@@ -351,8 +351,7 @@ To create new URLs the following template is used:
     ``VERSION`` variant of :ref:`hunter_config` entries, which is the case for all default
     Hunter package definitions.  Custom package definitions introduced with a ``URL``/``SHA1``
     variant on :ref:`hunter_config` in a project's local configuration, such as those included through
-    ``FILEPATH`` or ``LOCAL`` arguments to ``HunterGate()``, will be unaffected by this variable,
-    but can be similarly transformed through explicit calls to ``hunter_download_server_url()``.
+    ``FILEPATH`` or ``LOCAL`` arguments to ``HunterGate()``, will be unaffected by this variable.
     The ``git`` variants of :ref:`hunter_config`, namely ``GIT_SUBMODULE`` and ``GIT_SELF``, have no
     transformable URL and are are also unaffected by ``HUNTER_DOWNLOAD_SERVER``.
 

--- a/docs/reference/user-variables.rst
+++ b/docs/reference/user-variables.rst
@@ -348,12 +348,12 @@ To create new URLs the following template is used:
 .. note::
 
     ``HUNTER_DOWNLOAD_SERVER`` will be applied only to packages enabled with the standard
-    ``VERSION`` variant of ``hunter_config()`` entries, which is the case for all default
+    ``VERSION`` variant of :ref:`hunter_config` entries, which is the case for all default
     Hunter package definitions.  Custom package definitions introduced with a `URL/SHA1``
-    variant on ``hunter_config()`` in a project's local configuration, such as those included through
+    variant on :ref:`hunter_config` in a project's local configuration, such as those included through
     ``FILEPATH`` or ``LOCAL`` arguments to ``HunterGate()``, will be unaffected by this variable,
     but can be similarly transformed through explicit calls to ``hunter_download_server_url()``.
-    The ``git`` variants of ``hunter_config()``, namely ``GIT_SUBMODULE`` and ``GIT_SELF``, have no
+    The ``git`` variants of :ref:`hunter_config`, namely ``GIT_SUBMODULE`` and ``GIT_SELF``, have no
     transformable URL and are are also unaffected by ``HUNTER_DOWNLOAD_SERVER``.
 
 .. _hunter tls verify:

--- a/docs/reference/user-variables.rst
+++ b/docs/reference/user-variables.rst
@@ -345,6 +345,17 @@ To create new URLs the following template is used:
 
     This is the same structure as Hunter uses for its own :ref:`Download <layout deployed download>` directory.
 
+.. note::
+
+    ``HUNTER_DOWNLOAD_SERVER`` will be applied only to packages enabled with the standard 
+    ``VERSION`` variant of ``hunter_config()`` entries, which is the case for all default
+    Hunter package definitions.  Custom package definitions introduced with a `URL/SHA1``
+    variant on ``hunter_config()`` in a project's local configuration, such as those included through 
+    ``FILEPATH`` or ``LOCAL`` arguments to ``HunterGate()``, will be unaffected by this variable,
+    but can be similarly transformed through explicit calls to ``hunter_download_server_url()``.  
+    The ``git`` variants of ``hunter_config()``, namely ``GIT_SUBMODULE`` and ``GIT_SELF``, have no
+    transformable URL and are are also unaffected by ``HUNTER_DOWNLOAD_SERVER``.
+
 .. _hunter tls verify:
 
 HUNTER_TLS_VERIFY

--- a/docs/reference/user-variables.rst
+++ b/docs/reference/user-variables.rst
@@ -347,12 +347,12 @@ To create new URLs the following template is used:
 
 .. note::
 
-    ``HUNTER_DOWNLOAD_SERVER`` will be applied only to packages enabled with the standard 
+    ``HUNTER_DOWNLOAD_SERVER`` will be applied only to packages enabled with the standard
     ``VERSION`` variant of ``hunter_config()`` entries, which is the case for all default
     Hunter package definitions.  Custom package definitions introduced with a `URL/SHA1``
-    variant on ``hunter_config()`` in a project's local configuration, such as those included through 
+    variant on ``hunter_config()`` in a project's local configuration, such as those included through
     ``FILEPATH`` or ``LOCAL`` arguments to ``HunterGate()``, will be unaffected by this variable,
-    but can be similarly transformed through explicit calls to ``hunter_download_server_url()``.  
+    but can be similarly transformed through explicit calls to ``hunter_download_server_url()``.
     The ``git`` variants of ``hunter_config()``, namely ``GIT_SUBMODULE`` and ``GIT_SELF``, have no
     transformable URL and are are also unaffected by ``HUNTER_DOWNLOAD_SERVER``.
 

--- a/docs/reference/user-variables.rst
+++ b/docs/reference/user-variables.rst
@@ -353,7 +353,7 @@ To create new URLs the following template is used:
     variant on :ref:`hunter_config` in a project's local configuration, such as those included through
     ``FILEPATH`` or ``LOCAL`` arguments to ``HunterGate()``, will be unaffected by this variable.
     The ``git`` variants of :ref:`hunter_config`, namely ``GIT_SUBMODULE`` and ``GIT_SELF``, have no
-    transformable URL and are are also unaffected by ``HUNTER_DOWNLOAD_SERVER``.
+    transformable URL and are also unaffected by ``HUNTER_DOWNLOAD_SERVER``.
 
 .. _hunter tls verify:
 

--- a/docs/reference/user-variables.rst
+++ b/docs/reference/user-variables.rst
@@ -349,7 +349,7 @@ To create new URLs the following template is used:
 
     ``HUNTER_DOWNLOAD_SERVER`` will be applied only to packages enabled with the standard
     ``VERSION`` variant of :ref:`hunter_config` entries, which is the case for all default
-    Hunter package definitions.  Custom package definitions introduced with a `URL/SHA1``
+    Hunter package definitions.  Custom package definitions introduced with a ``URL``/``SHA1``
     variant on :ref:`hunter_config` in a project's local configuration, such as those included through
     ``FILEPATH`` or ``LOCAL`` arguments to ``HunterGate()``, will be unaffected by this variable,
     but can be similarly transformed through explicit calls to ``hunter_download_server_url()``.


### PR DESCRIPTION
Add a note regarding the expected behaviour of the `HUNTER_DOWNLOAD_SERVER` variable.  It is applied only to standard `VERSION` variants of `hunter_config()` entries.  This comment gives a hint to the user that they can transform `URL/SHA1` entries explicitly with `hunter_download_server_url()` if they desire.


* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**
