### PR TITLE
Strip leading spaces from compiler flags when building OpenSSL on Linux

### DIFF
--- a/cmake/projects/OpenSSL/hunter.cmake
+++ b/cmake/projects/OpenSSL/hunter.cmake
@@ -509,4 +509,4 @@ if(MINGW)
 endif()
 
 hunter_cacheable(OpenSSL)
-hunter_download(PACKAGE_NAME OpenSSL PACKAGE_INTERNAL_DEPS_ID "27")
+hunter_download(PACKAGE_NAME OpenSSL PACKAGE_INTERNAL_DEPS_ID "28")

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
@@ -108,6 +108,8 @@ elseif(OPENWRT)
   set(configure_opts "linux-generic32" "no-async")
 endif()
 
+string(REGEX REPLACE "^ " "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+
 # Pass C compiler through
 set(configure_command
     MACHINE=${CMAKE_SYSTEM_PROCESSOR}


### PR DESCRIPTION
<!--- Use this part of template for other type of changes. Remove the rest. -->
<!--- BEGIN -->

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

---
<!--- END -->
