### PR TITLE
Update Catch2 to 2.9.1

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -48,7 +48,7 @@ hunter_default_version(CLAPACK VERSION 3.2.1)
 hunter_default_version(CLI11 VERSION 1.8.0)
 hunter_default_version(CURL VERSION 7.60.0-p2)
 hunter_default_version(CapnProto VERSION 0.7.0)
-hunter_default_version(Catch VERSION 2.7.0)
+hunter_default_version(Catch VERSION 2.9.1)
 hunter_default_version(Clang VERSION 6.0.1-p0)
 hunter_default_version(ClangToolsExtra VERSION 6.0.1) # Clang
 hunter_default_version(Comet VERSION 4.0.2)

--- a/cmake/projects/Catch/hunter.cmake
+++ b/cmake/projects/Catch/hunter.cmake
@@ -13,6 +13,17 @@ hunter_add_version(
     PACKAGE_NAME
     Catch
     VERSION
+    "2.9.1"
+    URL
+    "https://github.com/catchorg/Catch2/archive/v2.9.1.tar.gz"
+    SHA1
+    caf84ac93f6b624b9583bc9712feb3fba9417c68
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Catch
+    VERSION
     "2.7.0"
     URL
     "https://github.com/catchorg/Catch2/archive/v2.7.0.tar.gz"


### PR DESCRIPTION
* I've followed [this guide](https://docs.hunter.sh/en/latest/creating-new/update.html)
  step by step carefully. **Yes**

* I've tested this package remotely and have excluded all broken builds.
  Here is the links to the Travis/AppVeyor with status "All passed":

  * https://ci.appveyor.com/project/kaihowl/hunter/builds/25341023
  * https://travis-ci.com/kaihowl/hunter/builds/115851369

This is a replacement for #1895.

The additional question from #1895 still stands:
> There is now an additional library integrated into Catch2, called nonius. This is disabled by default and [enabled with the flag CATCH_CONFIG_ENABLE_BENCHMARKING](https://github.com/catchorg/Catch2/blob/master/docs/configuration.md#other-toggles). Would it make sense to add an additional compilation unit to the examples that exercises this compilation flag? Or do we keep the testing to a minimum as to not run afoul of testing the entire library again as part of integrating it into Hunter?



