### PR TITLE
Proper parse of linker flags in pkg config files for MacOS

### DIFF
--- a/cmake/modules/hunter_pkgconfig_export_target.cmake
+++ b/cmake/modules/hunter_pkgconfig_export_target.cmake
@@ -59,7 +59,9 @@ function(hunter_pkgconfig_export_target PKG_CONFIG_MODULE PKG_GENERATE_SHARED)
       "PKG_CONFIG_MODULE ${PKG_CONFIG_MODULE} LDFLAGS: ${${PKG_CONFIG_PREFIX}_LDFLAGS}"
   )
   if(NOT "${${PKG_CONFIG_PREFIX}_LDFLAGS}" STREQUAL "")
-    list(APPEND link_libs ${${PKG_CONFIG_PREFIX}_LDFLAGS})
+    # turn "-framework;A;-framework;B" into "-framework A;-framework B"
+    string(REPLACE "-framework;" "-framework " ldflags "${${PKG_CONFIG_PREFIX}_LDFLAGS}")
+    list(APPEND link_libs ${ldflags})
   endif()
 
   hunter_status_debug(

--- a/cmake/projects/x11/hunter.cmake
+++ b/cmake/projects/x11/hunter.cmake
@@ -53,7 +53,7 @@ hunter_cmake_args(
 hunter_cacheable(x11)
 hunter_download(
     PACKAGE_NAME x11
-    PACKAGE_INTERNAL_DEPS_ID "6"
+    PACKAGE_INTERNAL_DEPS_ID "7"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libX11-xcb.la"
     "lib/libX11.la"

--- a/cmake/projects/x264/hunter.cmake
+++ b/cmake/projects/x264/hunter.cmake
@@ -36,6 +36,6 @@ hunter_cmake_args(x264 CMAKE_ARGS PKGCONFIG_EXPORT_TARGETS=x264)
 hunter_cacheable(x264)
 hunter_download(
     PACKAGE_NAME x264
-    PACKAGE_INTERNAL_DEPS_ID "2"
+    PACKAGE_INTERNAL_DEPS_ID "3"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "lib/pkgconfig/x264.pc"
 )

--- a/cmake/projects/xcb/hunter.cmake
+++ b/cmake/projects/xcb/hunter.cmake
@@ -63,6 +63,6 @@ hunter_pick_scheme(DEFAULT xcb)
 hunter_cacheable(xcb)
 hunter_download(
     PACKAGE_NAME xcb
-    PACKAGE_INTERNAL_DEPS_ID "5"
+    PACKAGE_INTERNAL_DEPS_ID "6"
     PACKAGE_UNRELOCATABLE_TEXT_FILES "${_xcb_text_files}"
 )


### PR DESCRIPTION
To fix the build issue for [examples/botan](https://travis-ci.org/Bjoe/hunter/jobs/549660956#L1183) we also need the proper parse of linker flags for ldflags. See also pull request #1481 

