### PR TITLE
Docs: Fixed broken link in zip.rst

### DIFF
--- a/docs/packages/pkg/zip.rst
+++ b/docs/packages/pkg/zip.rst
@@ -10,7 +10,7 @@
 zip
 ===
 
--  `Official <https://https://github.com/kuba--/zip>`__
+-  `Official <https://github.com/kuba--/zip>`__
 -  `Example <https://github.com/ruslo/hunter/blob/master/examples/zip/CMakeLists.txt>`__
 -  Added by `Rahul Sheth <https://github.com/rbsheth>`__ (`pr-1878 <https://github.com/ruslo/hunter/pull/1878>`__)
 


### PR DESCRIPTION
I was browsing the documentation and i noticed that the file zip.rst has a broken link.